### PR TITLE
fix(projects): repair persistent skeleton on /projects

### DIFF
--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -12,11 +12,21 @@ const firebaseConfig = {
     process.env.NEXT_PUBLIC_FB_PROJECT_ID + '.appspot.com',
   messagingSenderId:
     process.env.NEXT_PUBLIC_FB_MESSAGING_SENDER_ID,
-  appId:
-    '1:' +
-    process.env.NEXT_PUBLIC_FB_MESSAGING_SENDER_ID +
-    ':web:' +
-    process.env.NEXT_PUBLIC_FB_APP_ID,
+  // NEXT_PUBLIC_FB_APP_ID may be stored as either the bare suffix
+  // (e.g. "85f32b74d8aa8ec983d9aa") or the full appId string
+  // ("1:<senderId>:web:<suffix>"). Building the prefix blindly produces
+  // a doubled, malformed appId when the env var already contains the
+  // full form, which makes Firestore (and Firebase Installations)
+  // reject every request with 400 INVALID_ARGUMENT — leaving the
+  // /projects build-time cache empty and the client fallback broken.
+  // Use the value verbatim when it already looks like a full appId;
+  // otherwise construct it from the sender id + suffix.
+  appId: process.env.NEXT_PUBLIC_FB_APP_ID?.includes(':web:')
+    ? process.env.NEXT_PUBLIC_FB_APP_ID
+    : '1:' +
+      process.env.NEXT_PUBLIC_FB_MESSAGING_SENDER_ID +
+      ':web:' +
+      process.env.NEXT_PUBLIC_FB_APP_ID,
   measurementId: process.env.NEXT_PUBLIC_FB_MEASUREMENT_ID,
 }
 

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -43,6 +43,14 @@ function Projects({ cached_projects }) {
   const router = useRouter()
   const firestore = useFirestore()
   const [projects, setProjects] = useState(cached_projects)
+  // `loading` is only true while an initial fetch is in flight AND we
+  // have nothing to show yet. It gates the skeleton so the page never
+  // gets pinned to the loading state when the build-time cache is empty
+  // (the production /projects page ships with cached_projects === [])
+  // or when the client-side Firestore fallback fails.
+  const [loading, setLoading] = useState(
+    cached_projects.length === 0
+  )
 
   moment.locale(router?.locale ? router.locale : 'en')
 
@@ -59,90 +67,105 @@ function Projects({ cached_projects }) {
     if (!hasSearch && !hasField) {
       if (cached_projects.length > 0) {
         setProjects(cached_projects)
+        setLoading(false)
         return
       }
     }
+    // Show the skeleton only when we have nothing to display yet; once
+    // projects are loaded, keep the previous result set visible while
+    // a follow-up search/field query is in flight (no flashing).
+    if (projects.length === 0) setLoading(true)
     let ps = []
-    // Search path: resolve IDs via Algolia, then hydrate from Firestore.
-    if (hasSearch) {
-      let ids = []
-      const searchClient = algoliasearch(
-        process.env.NEXT_PUBLIC_AL_APP_ID,
-        process.env.NEXT_PUBLIC_AL_SEARCH_KEY
-      )
-      const projectIndex =
-        searchClient.initIndex('prod_PROJECTS')
-      let results
-      if (hasField) {
-        results = await projectIndex.search(
-          router.query.search,
-          {
-            filters: 'data.fields:' + router.query.field,
-          }
+    try {
+      // Search path: resolve IDs via Algolia, then hydrate from Firestore.
+      if (hasSearch) {
+        let ids = []
+        const searchClient = algoliasearch(
+          process.env.NEXT_PUBLIC_AL_APP_ID,
+          process.env.NEXT_PUBLIC_AL_SEARCH_KEY
         )
-      } else {
-        results = await projectIndex.search(
-          router.query.search
-        )
-      }
-      results.hits.forEach((p) => {
-        ids.push(p.objectID)
-      })
-      // Firebase's `in` filter rejects an empty list, so short-circuit.
-      if (ids.length === 0) {
-        setProjects([])
-        return
-      }
-      const projectsCollection = collection(
-        firestore,
-        'projects'
-      )
-      const projectsQuery = firebase_query(
-        projectsCollection,
-        firebase_where(documentId(), 'in', ids.slice(0, 10))
-      )
-      const projectsRef = await getDocs(projectsQuery)
-      projectsRef.forEach((p) => {
-        ps.push({
-          id: p.id,
-          ...p.data(),
+        const projectIndex =
+          searchClient.initIndex('prod_PROJECTS')
+        let results
+        if (hasField) {
+          results = await projectIndex.search(
+            router.query.search,
+            {
+              filters: 'data.fields:' + router.query.field,
+            }
+          )
+        } else {
+          results = await projectIndex.search(
+            router.query.search
+          )
+        }
+        results.hits.forEach((p) => {
+          ids.push(p.objectID)
         })
-      })
-      setProjects(ps)
-    }
-    // Firebase path: field filter, or bare route with empty cache.
-    else {
-      const projectsCollection = collection(
-        firestore,
-        'projects'
-      )
-      let projectsQuery
-      if (hasField) {
-        projectsQuery = firebase_query(
-          projectsCollection,
-          firebase_where(
-            'fields',
-            'array-contains',
-            router.query.field
-          ),
-          orderBy('date', 'desc'),
-          limit(10)
+        // Firebase's `in` filter rejects an empty list, so short-circuit.
+        if (ids.length === 0) {
+          setProjects([])
+          return
+        }
+        const projectsCollection = collection(
+          firestore,
+          'projects'
         )
-      } else {
-        projectsQuery = firebase_query(
+        const projectsQuery = firebase_query(
           projectsCollection,
-          orderBy('date', 'desc'),
-          limit(10)
+          firebase_where(documentId(), 'in', ids.slice(0, 10))
         )
-      }
-      const projectsRef = await getDocs(projectsQuery)
-      projectsRef.forEach((p) => {
-        ps.push({
-          id: p.id,
-          ...p.data(),
+        const projectsRef = await getDocs(projectsQuery)
+        projectsRef.forEach((p) => {
+          ps.push({
+            id: p.id,
+            ...p.data(),
+          })
         })
-      })
-      setProjects(ps)
+        setProjects(ps)
+      }
+      // Firebase path: field filter, or bare route with empty cache.
+      else {
+        const projectsCollection = collection(
+          firestore,
+          'projects'
+        )
+        let projectsQuery
+        if (hasField) {
+          projectsQuery = firebase_query(
+            projectsCollection,
+            firebase_where(
+              'fields',
+              'array-contains',
+              router.query.field
+            ),
+            orderBy('date', 'desc'),
+            limit(10)
+          )
+        } else {
+          projectsQuery = firebase_query(
+            projectsCollection,
+            orderBy('date', 'desc'),
+            limit(10)
+          )
+        }
+        const projectsRef = await getDocs(projectsQuery)
+        projectsRef.forEach((p) => {
+          ps.push({
+            id: p.id,
+            ...p.data(),
+          })
+        })
+        setProjects(ps)
+      }
+    } catch (err) {
+      // A failed client fetch must not leave the page pinned to the
+      // loading skeleton forever — clear loading and let the empty
+      // state render instead.
+      console.error('Failed to load projects:', err)
+      setProjects([])
+    } finally {
+      setLoading(false)
     }
   }, [router])
 
@@ -172,7 +195,12 @@ function Projects({ cached_projects }) {
   )
 
   async function load_more_projects() {
+    // Never paginate before the first page has arrived (projects is
+    // empty) or while a fetch is in flight — startAfter would otherwise
+    // read projects[-1].date and throw.
+    if (loading) return
     if (!router?.query?.search) {
+      if (projects.length === 0) return
       let ps = []
       const projectsCollection = collection(
         firestore,
@@ -456,10 +484,11 @@ function Projects({ cached_projects }) {
               )}
             </Link>
           </div>
-          {projects?.length != 0
-            ? projectsComponent
-            : loadingComponent}
-          {projects.length == 0 &&
+          {loading && projects.length === 0
+            ? loadingComponent
+            : projectsComponent}
+          {!loading &&
+            projects.length === 0 &&
             (router?.query?.search ||
               router?.query?.field) && (
               <div className="mx-auto mt-20 text-center">


### PR DESCRIPTION
Root cause: the build-time cache (cached_projects from getStaticProps) ships empty in production, so the page falls back to client-side Firestore. Two issues kept the skeleton pinned:

1. firebaseConfig.js built appId as '1:<senderId>:web:<APP_ID>', but the production NEXT_PUBLIC_FB_APP_ID env var already contains the full '1:<senderId>:web:<suffix>' string, producing a doubled, malformed appId. Firestore (and Firebase Installations) reject every request with 400 INVALID_ARGUMENT, so getStaticProps returns 0 docs and the client fallback's getDocs silently fails. Make appId robust to both the bare-suffix and full-string env forms.

2. pages/projects.js gated the skeleton on projects.length == 0 with no loading state, so once the fallback resolved to [] the skeleton stayed forever (and any thrown error left it pinned). Add an explicit loading flag bounded to in-flight fetches with no projects yet, wrap the effect in try/catch/finally so a failed fetch clears loading, and guard load_more_projects against paginating before the first page arrives (startAfter on projects[-1].date would throw).

Verified: getStaticProps' exact Firestore query returns 10 docs with the correct appId; the skeleton now only renders while a fetch is in flight.