### PR TITLE
fix: resolve ESLint errors failing Vercel build

### DIFF
--- a/components/Banner.js
+++ b/components/Banner.js
@@ -1,13 +1,10 @@
 import { useEffect, useState } from 'react'
 
-import { useRouter } from 'next/router'
-
 import { RichText } from 'prismic-reactjs'
 var Prismic = require('@prismicio/client')
 
 function Banner({ closeBanner }) {
   const [banner, setBanner] = useState(null)
-  const router = useRouter()
   useEffect(async () => {
     const apiEndpoint =
       'https://sciteens.cdn.prismic.io/api/v2'

--- a/components/Discussion.js
+++ b/components/Discussion.js
@@ -4,7 +4,7 @@ import {
   addDoc,
   orderBy,
 } from '@firebase/firestore'
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback } from 'react'
 import {
   useFirestore,
   useFirestoreCollectionData,
@@ -18,8 +18,7 @@ import debounce from 'lodash.debounce'
 import moment from 'moment'
 
 export default function Discussion({ type, item_id }) {
-  const { authStatus, data: signInCheckResult } =
-    useSigninCheck()
+  const { data: signInCheckResult } = useSigninCheck()
   const firestore = useFirestore()
 
   let discussionCollection = collection(
@@ -48,7 +47,6 @@ export default function Discussion({ type, item_id }) {
   const [error_reply, setErrorReply] = useState('')
   const [error_reply_index, setErrorReplyIndex] =
     useState(0)
-  const [model, setModel] = useState({})
 
   const router = useRouter()
 
@@ -164,7 +162,7 @@ export default function Discussion({ type, item_id }) {
         .checkValidity()
     }
     e.preventDefault()
-    let commentDoc = await addDoc(
+    await addDoc(
       collection(firestore, type, item_id, 'discussion'),
       {
         date: new Date().toISOString(),
@@ -236,7 +234,7 @@ export default function Discussion({ type, item_id }) {
         >
           <button
             type="reset"
-            onClick={(e) => {
+            onClick={() => {
               setReplyingToName('')
               setReplyingToId('')
               setComment('')
@@ -267,7 +265,7 @@ export default function Discussion({ type, item_id }) {
         discussion.map((comment, key) => {
           if (comment.reply_to_id == '')
             return (
-              <div>
+              <div key={comment.id}>
                 <div
                   id={comment.id}
                   key={comment.date}
@@ -300,7 +298,7 @@ export default function Discussion({ type, item_id }) {
                   <div className="flex justify-end">
                     <button
                       className="text-gray-700 hover:text-black"
-                      onClick={(e) =>
+                      onClick={() =>
                         handleReplyTo(comment, key)
                       }
                     >
@@ -328,7 +326,6 @@ export default function Discussion({ type, item_id }) {
                     id={'reply' + key}
                     required
                     rows="3"
-                    resize="none"
                     className={`w-full resize-none appearance-none border-transparent bg-white p-2 leading-tight shadow focus:shadow-lg 
                                 ${
                                   replyingToId == comment.id
@@ -349,7 +346,7 @@ export default function Discussion({ type, item_id }) {
                   <div className="flex w-min flex-col">
                     <button
                       type="reset"
-                      onClick={(e) => {
+                      onClick={() => {
                         setReplyingToName('')
                         setReplyingToId('')
                         setComment('')
@@ -392,7 +389,10 @@ export default function Discussion({ type, item_id }) {
                   {discussion.map((reply) => {
                     if (comment.id === reply.reply_to_id)
                       return (
-                        <div className="flex w-full flex-row">
+                        <div
+                          key={reply.id}
+                          className="flex w-full flex-row"
+                        >
                           <div className="ml-5 mr-5 w-[2px] bg-gray-200 md:ml-8 md:mr-8" />
                           <div className="w-full">
                             <div

--- a/components/File.js
+++ b/components/File.js
@@ -1,10 +1,7 @@
-import { useEffect, useState } from 'react'
-
 export default function RenderFile({
   file,
   id,
   removeFile,
-  setPhoto,
 }) {
   switch (file?.type) {
     case 'application/vnd.openxmlformats-officedocument.presentationml.presentation':
@@ -13,6 +10,7 @@ export default function RenderFile({
           className="flex w-full justify-between rounded-lg bg-white shadow"
           href={URL.createObjectURL(file)}
           target="_blank"
+          rel="noreferrer"
         >
           <img
             src="/assets/files/file-document-powerpoint-presentation-report-44515.svg"
@@ -41,13 +39,13 @@ export default function RenderFile({
           )}
         </a>
       )
-      break
     case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
       return (
         <a
           className="flex w-full justify-between rounded-lg bg-white shadow"
           href={URL.createObjectURL(file)}
           target="_blank"
+          rel="noreferrer"
         >
           <img
             src="/assets/files/file-document-docx-text-type-word-writing-44508.svg"
@@ -77,13 +75,13 @@ export default function RenderFile({
           )}
         </a>
       )
-      break
     case 'application/pdf':
       return (
         <a
           className="flex w-full justify-between rounded-lg bg-white shadow"
           href={URL.createObjectURL(file)}
           target="_blank"
+          rel="noreferrer"
         >
           <img
             src="/assets/files/file-pdf-acrobat-document-adobe-pdf-icon-reader-44504.svg"
@@ -112,7 +110,6 @@ export default function RenderFile({
           )}
         </a>
       )
-      break
     case 'image/jpeg':
     case 'image/png':
     case 'image/jpg':
@@ -121,10 +118,11 @@ export default function RenderFile({
           className="flex w-full justify-between rounded-lg bg-white shadow transition-all duration-500"
           href={URL.createObjectURL(file)}
           target="_blank"
+          rel="noreferrer"
         >
           <img
             src={URL.createObjectURL(file)}
-            alt="Project Image"
+            alt="Project"
             className="h-16 w-[10%] rounded-l-lg object-cover object-center"
           />
           <div className="ml-2 flex-1 p-2 text-left line-clamp-1">
@@ -147,12 +145,10 @@ export default function RenderFile({
           )}
         </a>
       )
-      break
     default:
       return (
         <a className="flex w-full justify-between rounded-lg bg-white shadow">
           <img
-            v-else
             src="/assets/files/file-doc-document-filetypes-text-word-xls-44511.svg"
             alt="File Icon"
             className="m-1 h-11 w-11"
@@ -181,6 +177,5 @@ export default function RenderFile({
           </div>
         </a>
       )
-      break
   }
 }

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,11 +1,10 @@
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
-import { i18n, useTranslation } from 'next-i18next'
+import { i18n } from 'next-i18next'
 
 export default function Footer() {
   const router = useRouter()
-  const { t } = useTranslation('common')
 
   useEffect(() => {
     if (router.isReady && i18n?.isInitialized) {
@@ -66,6 +65,7 @@ export default function Footer() {
                     <a
                       href="mailto:info@sciteens.com"
                       target="_blank"
+                      rel="noreferrer"
                     >
                       {i18n.t('footer.contact')}
                     </a>
@@ -79,6 +79,7 @@ export default function Footer() {
                     <a
                       href="https://docs.google.com/forms/d/e/1FAIpQLScbDPaXgLflGrV3NSXpOTSFYoU2dIcEFy-xT2Kz9-6dMUYotQ/viewform?usp=sf_link"
                       target="_blank"
+                      rel="noreferrer"
                     >
                       {i18n.t('footer.feedback')}
                     </a>

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -48,7 +48,7 @@ export default function NavBar() {
     setShowMobileNav(false)
   }
 
-  const { t } = useTranslation('common')
+  useTranslation('common')
 
   useEffect(() => {
     if (router.isReady && i18n?.isInitialized)
@@ -201,6 +201,17 @@ export default function NavBar() {
                     onClick={() =>
                       setShowProfileMenu(!showProfileMenu)
                     }
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (
+                        e.key === 'Enter' ||
+                        e.key === ' '
+                      ) {
+                        e.preventDefault()
+                        setShowProfileMenu(!showProfileMenu)
+                      }
+                    }}
                   >
                     <button className="relative h-10 w-10 rounded-full border-4 border-white hover:border-gray-100 hover:shadow-inner">
                       {signInCheckResult?.user?.photoURL ? (
@@ -210,6 +221,7 @@ export default function NavBar() {
                             signInCheckResult.user.photoURL
                           }
                           className="rounded-full object-contain"
+                          alt=""
                         />
                       ) : (
                         <svg
@@ -228,6 +240,17 @@ export default function NavBar() {
                       onClick={() =>
                         setShowProfileMenu(false)
                       }
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={(e) => {
+                        if (
+                          e.key === 'Enter' ||
+                          e.key === ' '
+                        ) {
+                          e.preventDefault()
+                          setShowProfileMenu(false)
+                        }
+                      }}
                       className={`absolute top-14 right-4 z-50 w-32 rounded-lg border border-gray-200 bg-white p-4 shadow-lg ${
                         showProfileMenu ? '' : 'hidden'
                       }`}
@@ -272,6 +295,17 @@ export default function NavBar() {
               <Link href="/">
                 <div
                   onClick={() => setShowMobileNav(false)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (
+                      e.key === 'Enter' ||
+                      e.key === ' '
+                    ) {
+                      e.preventDefault()
+                      setShowMobileNav(false)
+                    }
+                  }}
                   className={`mb-4 flex flex-row rounded-lg py-3 px-6
                         ${
                           router.pathname == '/'
@@ -293,6 +327,17 @@ export default function NavBar() {
               <Link href="/about">
                 <div
                   onClick={() => setShowMobileNav(false)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (
+                      e.key === 'Enter' ||
+                      e.key === ' '
+                    ) {
+                      e.preventDefault()
+                      setShowMobileNav(false)
+                    }
+                  }}
                   className={`mb-4 flex flex-row rounded-lg py-3 px-6
                         ${
                           router.pathname.includes('about')
@@ -316,6 +361,17 @@ export default function NavBar() {
               <Link href="/articles">
                 <div
                   onClick={() => setShowMobileNav(false)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (
+                      e.key === 'Enter' ||
+                      e.key === ' '
+                    ) {
+                      e.preventDefault()
+                      setShowMobileNav(false)
+                    }
+                  }}
                   className={`mb-4 flex flex-row rounded-lg py-3 px-6
                         ${
                           router.pathname.includes(
@@ -339,6 +395,17 @@ export default function NavBar() {
               <Link href="/projects">
                 <div
                   onClick={() => setShowMobileNav(false)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (
+                      e.key === 'Enter' ||
+                      e.key === ' '
+                    ) {
+                      e.preventDefault()
+                      setShowMobileNav(false)
+                    }
+                  }}
                   className={`mb-4 flex flex-row rounded-lg py-3 px-6
                         ${
                           router.pathname.includes(
@@ -362,6 +429,17 @@ export default function NavBar() {
               <Link href="/courses">
                 <div
                   onClick={() => setShowMobileNav(false)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (
+                      e.key === 'Enter' ||
+                      e.key === ' '
+                    ) {
+                      e.preventDefault()
+                      setShowMobileNav(false)
+                    }
+                  }}
                   className={`mb-4 flex flex-row rounded-lg py-3 px-6
                         ${
                           router.pathname.includes(
@@ -385,6 +463,17 @@ export default function NavBar() {
               <Link href="/getinvolved">
                 <div
                   onClick={() => setShowMobileNav(false)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (
+                      e.key === 'Enter' ||
+                      e.key === ' '
+                    ) {
+                      e.preventDefault()
+                      setShowMobileNav(false)
+                    }
+                  }}
                   className={`mb-4 flex flex-row rounded-lg py-3 px-6
                         ${
                           router.pathname.includes(
@@ -410,6 +499,17 @@ export default function NavBar() {
               <Link href="/donate">
                 <div
                   onClick={() => setShowMobileNav(false)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (
+                      e.key === 'Enter' ||
+                      e.key === ' '
+                    ) {
+                      e.preventDefault()
+                      setShowMobileNav(false)
+                    }
+                  }}
                   className={`mb-4 flex flex-row rounded-lg py-3 px-6
                         ${
                           router.pathname.includes('donate')
@@ -432,6 +532,17 @@ export default function NavBar() {
                 <Link href="/signup">
                   <div
                     onClick={() => setShowMobileNav(false)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (
+                        e.key === 'Enter' ||
+                        e.key === ' '
+                      ) {
+                        e.preventDefault()
+                        setShowMobileNav(false)
+                      }
+                    }}
                     className={`mb-4 flex flex-row rounded-lg py-3 px-6
                             ${
                               router.pathname.includes(
@@ -469,6 +580,7 @@ export default function NavBar() {
                             signInCheckResult.user.photoURL
                           }
                           className="mr-6 h-10 rounded-full"
+                          alt=""
                         />
                       ) : (
                         <svg
@@ -504,13 +616,14 @@ export default function NavBar() {
                                             : 'bg-gray-400'
                                         }`}
                           />
-                          <p
+                          <button
+                            type="button"
                             onClick={() =>
                               setShowMobileNav(false)
                             }
                           >
                             {i18n.t('navigation.profile')}
-                          </p>
+                          </button>
                         </div>
                       </Link>
                       <div className="h-2 w-0.5 bg-gray-400" />

--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -1,5 +1,20 @@
 import { usePagination, DOTS } from './usePagination'
 import './pagination.scss'
+
+const classnames = (...args) => {
+  const classes = []
+  for (const arg of args) {
+    if (typeof arg === 'string') {
+      if (arg) classes.push(arg)
+    } else if (typeof arg === 'object' && arg !== null) {
+      for (const key in arg) {
+        if (arg[key]) classes.push(key)
+      }
+    }
+  }
+  return classes.join(' ')
+}
+
 const Pagination = (props) => {
   const {
     onPageChange,
@@ -42,15 +57,23 @@ const Pagination = (props) => {
         className={classnames('pagination-item', {
           disabled: currentPage === 1,
         })}
-        onClick={onPrevious}
       >
-        <div className="arrow left" />
+        <button
+          type="button"
+          onClick={onPrevious}
+          className="pagination-button"
+        >
+          <div className="arrow left" />
+        </button>
       </li>
-      {paginationRange.map((pageNumber) => {
+      {paginationRange.map((pageNumber, index) => {
         // If the pageItem is a DOT, render the DOTS unicode character
         if (pageNumber === DOTS) {
           return (
-            <li className="pagination-item dots">
+            <li
+              key={`dots-${index}`}
+              className="pagination-item dots"
+            >
               &#8230;
             </li>
           )
@@ -59,12 +82,18 @@ const Pagination = (props) => {
         // Render our Page Pills
         return (
           <li
+            key={pageNumber}
             className={classnames('pagination-item', {
               selected: pageNumber === currentPage,
             })}
-            onClick={() => onPageChange(pageNumber)}
           >
-            {pageNumber}
+            <button
+              type="button"
+              onClick={() => onPageChange(pageNumber)}
+              className="pagination-button"
+            >
+              {pageNumber}
+            </button>
           </li>
         )
       })}
@@ -73,9 +102,14 @@ const Pagination = (props) => {
         className={classnames('pagination-item', {
           disabled: currentPage === lastPage,
         })}
-        onClick={onNext}
       >
-        <div className="arrow right" />
+        <button
+          type="button"
+          onClick={onNext}
+          className="pagination-button"
+        >
+          <div className="arrow right" />
+        </button>
       </li>
     </ul>
   )

--- a/components/ProfilePhoto.js
+++ b/components/ProfilePhoto.js
@@ -27,7 +27,7 @@ export default function ProfilePhoto({ uid }) {
       {img_src ? (
         <img
           src={img_src}
-          alt="Profile Photo"
+          alt="Profile"
           className="h-full w-full rounded-full object-fill"
         ></img>
       ) : (

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,9 +1,7 @@
 import Link from 'next/link'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { useTranslation } from 'next-i18next'
 
 export default function FourOhFour() {
-  const { t } = useTranslation('common')
   return (
     <>
       <div className="mx-auto mt-20 min-h-screen w-full text-center">

--- a/pages/about.js
+++ b/pages/about.js
@@ -4,323 +4,323 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
 
 export default function About() {
-    const { t } = useTranslation('common')
-    const [members, setMembers] = useState(
-        [
-            {
-                name: 'Sri Kondapalli',
-                image: 'sri.jpg',
-                about: t('about.about_sri'),
-                current: false,
-            },
-            {
-                name: 'Rohan Bolle',
-                image: 'rohan.jpg',
-                about: t('about.about_rohan'),
-                current: false,
-            },
-            {
-                name: 'Aneesha Acharya',
-                image: 'aneesha.jpg',
-                about: t('about.about_aneesha'),
-                current: false,
-            },
-            {
-                name: 'Angelo Chen',
-                image: 'angelo.jpg',
-                about: t('about.about_angelo'),
-                current: false,
-            },
-            {
-                name: 'Sonica Prakash',
-                image: 'sonica.jpg',
-                about: t('about.about_sonica'),
-                current: false,
-            },
-            {
-                name: 'John Sutor',
-                image: 'john.jpg',
-                about: t('about.about_john'),
-                current: false,
-            },
-            {
-                name: 'Haley Gardner',
-                image: 'haley.jpg',
-                about:
-                    'Haley is a member of five Dungeons & Dragons groups.',
-                current: false,
-            },
-            {
-                name: 'Carlos Mercado-Lara',
-                image: 'carlos.jpg',
-                about: t('about.about_carlos'),
-                current: false,
-            },
-            {
-                name: 'Erin Kang',
-                image: 'erin.jpg',
-                about: t('about.about_erin'),
-                current: false,
-            },
-            {
-                name: 'Grace Jiang',
-                image: 'grace.jpg',
-                about: t('about.about_grace'),
-                current: false,
-            },
-            {
-                name: 'Aarti Kalamangalam',
-                image: 'aarti.jpg',
-                about: t('about.about_aarti'),
-                current: false,
-            },
-            {
-                name: 'Iman Khalid',
-                image: 'iman.jpg',
-                about: t('about.about_iman'),
-                current: false,
-            },
-            {
-                name: 'Liane Xu',
-                image: 'liane.jpg',
-                about: t('about.about_liane'),
-                current: false,
-            },
-            {
-                name: 'Alae Belkhadir',
-                image: 'alae.jpg',
-                about: t('about.about_alae'),
-                current: false,
-            },
-            {
-                name: 'Sanjana Gade',
-                image: 'sanjana.jpg',
-                about: t('about.about_sanjana'),
-                current: false,
-            },
-            {
-                name: 'Joud Abdul Baki',
-                image: 'joud.jpg',
-                about: t('about.about_joud'),
-                current: false,
-            },
-            {
-                name: 'Philip Antonopoulos',
-                image: 'philip.jpg',
-                about: t('about.about_philip'),
-                current: false,
-            },
-            {
-                name: 'Srishti Swaminathan',
-                image: 'srishti.jpg',
-                about: t('about.about_srishti'),
-                current: false,
-            },
-            {
-                name: 'Grace Nyakarombo',
-                image: 'grace2.jpg',
-                about: t('about.about_grace2'),
-                current: false,
-            },
-            {
-                name: 'Tasman Rosenfeld',
-                image: 'tasman.jpg',
-                about: t('about.about_tasman'),
-                current: false,
-            },
-            {
-                name: "Luke Sutor",
-                image: "luke.jpg",
-                about: t("about.about_luke"),
-                current: false
-            },
-            {
-                name: "Hannah Scaglione",
-                image: "hannah.jpg",
-                about:
-                    t("about.about_hannah"),
-                current: false
-            },
-            {
-                name: "Ohm Parikh ",
-                image: "ohm.jpg",
-                about: t("about.about_ohm"),
-                current: false
-            },
-            {
-                name: "Akash Patel",
-                image: "akash.jpg",
-                about: t("about.about_akash"),
-                current: false
-            },
-            {
-                name: "Eduard Shkulipa",
-                image: "eduard.jpg",
-                about: t("about.about_eduard"),
-                current: false
-            },
-            {
-                name: "Aya Khalaf",
-                image: "aya.jpg",
-                about:
-                    t("about.about_aya"),
-                current: false
-            },
-            {
-                name: "Angelica Castillejos",
-                image: "angelica.jpg",
-                about:
-                    t("about.about_angelica"),
-                current: false
-            },
-            {
-                name: "Ashley Pelton",
-                image: "ashley.jpg",
-                about:
-                    t("about.about_ashley"),
-                current: false
-            },
-        ]
-    )
+  const { t } = useTranslation('common')
+  const [members, setMembers] = useState([
+    {
+      name: 'Sri Kondapalli',
+      image: 'sri.jpg',
+      about: t('about.about_sri'),
+      current: false,
+    },
+    {
+      name: 'Rohan Bolle',
+      image: 'rohan.jpg',
+      about: t('about.about_rohan'),
+      current: false,
+    },
+    {
+      name: 'Aneesha Acharya',
+      image: 'aneesha.jpg',
+      about: t('about.about_aneesha'),
+      current: false,
+    },
+    {
+      name: 'Angelo Chen',
+      image: 'angelo.jpg',
+      about: t('about.about_angelo'),
+      current: false,
+    },
+    {
+      name: 'Sonica Prakash',
+      image: 'sonica.jpg',
+      about: t('about.about_sonica'),
+      current: false,
+    },
+    {
+      name: 'John Sutor',
+      image: 'john.jpg',
+      about: t('about.about_john'),
+      current: false,
+    },
+    {
+      name: 'Haley Gardner',
+      image: 'haley.jpg',
+      about:
+        'Haley is a member of five Dungeons & Dragons groups.',
+      current: false,
+    },
+    {
+      name: 'Carlos Mercado-Lara',
+      image: 'carlos.jpg',
+      about: t('about.about_carlos'),
+      current: false,
+    },
+    {
+      name: 'Erin Kang',
+      image: 'erin.jpg',
+      about: t('about.about_erin'),
+      current: false,
+    },
+    {
+      name: 'Grace Jiang',
+      image: 'grace.jpg',
+      about: t('about.about_grace'),
+      current: false,
+    },
+    {
+      name: 'Aarti Kalamangalam',
+      image: 'aarti.jpg',
+      about: t('about.about_aarti'),
+      current: false,
+    },
+    {
+      name: 'Iman Khalid',
+      image: 'iman.jpg',
+      about: t('about.about_iman'),
+      current: false,
+    },
+    {
+      name: 'Liane Xu',
+      image: 'liane.jpg',
+      about: t('about.about_liane'),
+      current: false,
+    },
+    {
+      name: 'Alae Belkhadir',
+      image: 'alae.jpg',
+      about: t('about.about_alae'),
+      current: false,
+    },
+    {
+      name: 'Sanjana Gade',
+      image: 'sanjana.jpg',
+      about: t('about.about_sanjana'),
+      current: false,
+    },
+    {
+      name: 'Joud Abdul Baki',
+      image: 'joud.jpg',
+      about: t('about.about_joud'),
+      current: false,
+    },
+    {
+      name: 'Philip Antonopoulos',
+      image: 'philip.jpg',
+      about: t('about.about_philip'),
+      current: false,
+    },
+    {
+      name: 'Srishti Swaminathan',
+      image: 'srishti.jpg',
+      about: t('about.about_srishti'),
+      current: false,
+    },
+    {
+      name: 'Grace Nyakarombo',
+      image: 'grace2.jpg',
+      about: t('about.about_grace2'),
+      current: false,
+    },
+    {
+      name: 'Tasman Rosenfeld',
+      image: 'tasman.jpg',
+      about: t('about.about_tasman'),
+      current: false,
+    },
+    {
+      name: 'Luke Sutor',
+      image: 'luke.jpg',
+      about: t('about.about_luke'),
+      current: false,
+    },
+    {
+      name: 'Hannah Scaglione',
+      image: 'hannah.jpg',
+      about: t('about.about_hannah'),
+      current: false,
+    },
+    {
+      name: 'Ohm Parikh ',
+      image: 'ohm.jpg',
+      about: t('about.about_ohm'),
+      current: false,
+    },
+    {
+      name: 'Akash Patel',
+      image: 'akash.jpg',
+      about: t('about.about_akash'),
+      current: false,
+    },
+    {
+      name: 'Eduard Shkulipa',
+      image: 'eduard.jpg',
+      about: t('about.about_eduard'),
+      current: false,
+    },
+    {
+      name: 'Aya Khalaf',
+      image: 'aya.jpg',
+      about: t('about.about_aya'),
+      current: false,
+    },
+    {
+      name: 'Angelica Castillejos',
+      image: 'angelica.jpg',
+      about: t('about.about_angelica'),
+      current: false,
+    },
+    {
+      name: 'Ashley Pelton',
+      image: 'ashley.jpg',
+      about: t('about.about_ashley'),
+      current: false,
+    },
+  ])
 
-    useEffect(() => {
-        // Randomize the order of the members
-        let randomized_members = [...members]
-        randomized_members.sort(() => Math.random() - 0.5)
-        setMembers(randomized_members)
-    }, [])
+  useEffect(() => {
+    // Randomize the order of the members
+    let randomized_members = [...members]
+    randomized_members.sort(() => Math.random() - 0.5)
+    setMembers(randomized_members)
+  }, [])
 
-    // Intersection Observer Stuff
-    useEffect(() => {
-        const member_elements =
-            document.querySelectorAll('.member')
-        console.log(member_elements)
+  // Intersection Observer Stuff
+  useEffect(() => {
+    const member_elements =
+      document.querySelectorAll('.member')
+    console.log(member_elements)
 
-        const observor = new IntersectionObserver(
-            (entries) => {
-                entries.forEach((entry) => {
-                    if (entry.isIntersecting) {
-                        entry.target.classList.remove('scale-0')
-                        observor.unobserve(entry.target)
-                    }
-                })
-            },
-            {
-                threshold: 0.85,
-            }
-        )
-
-        member_elements.forEach((member) => {
-            observor.observe(member)
+    const observor = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.remove('scale-0')
+            observor.unobserve(entry.target)
+          }
         })
-    }, [])
-
-    return (
-        <div>
-            <Head>
-                <title>About Us | SciTeens</title>
-                <link rel="icon" href="/favicon.ico" />
-                <meta
-                    name="description"
-                    content="SciTeens About Page"
-                />
-                <meta
-                    name="keywords"
-                    content="SciTeens, sciteens, science, teen science"
-                />
-                <meta property="og:type" content="website" />
-                <meta
-                    name="og:image"
-                    content="/assets/sciteens_initials.jpg"
-                />
-            </Head>
-            <main>
-                <div className="mx-auto w-full px-4 py-8 text-left md:p-8 lg:w-5/6">
-                    <h1 className="my-4 text-center text-3xl font-semibold md:text-5xl">
-                        {t('about.on_a_mission')}
-                    </h1>
-                    <p className="mx-0 mb-12 text-center text-base md:text-xl lg:mx-24">
-                        {t('about.we_strive')}
-                    </p>
-                    <div className="mb-8 inline-grid h-full w-full grid-cols-2 place-items-center lg:grid-cols-3">
-                        {members.filter(m => m.current == true).map((member) => {
-                            return (
-                                <div
-                                    key={member.name}
-                                    className="member relative mb-6 h-[90%] w-11/12 scale-0 rounded-lg bg-white p-4 shadow transition-all duration-500 md:p-8"
-                                >
-                                    <img
-                                        loading="lazy"
-                                        src={`assets/headshots/${member.image}`}
-                                        alt={member.name}
-                                        className="m-auto mb-4 h-20 w-20 rounded-full shadow lg:h-28 lg:w-28"
-                                    />
-                                    <p className="mb-2 text-center text-base font-semibold md:text-2xl">
-                                        {member.name}
-                                    </p>
-                                    <p
-                                        className={`hidden text-center text-gray-700 md:block
-                                    ${member.name ===
-                                                'Angelica Castillejos' ||
-                                                member.name ===
-                                                'Tasman Rosenfeld'
-                                                ? 'text-sm'
-                                                : 'text-base'
-                                            }`}
-                                    >
-                                        {member.about}
-                                    </p>
-                                </div>
-                            )
-                        })}
-                    </div>
-
-                    <h2 className="mb-6 text-center text-2xl font-bold md:text-3xl">
-                        Previous Members
-                    </h2>
-                    <div className="mb-8 inline-grid h-full w-full grid-cols-2 place-items-center lg:grid-cols-3">
-                        {members.filter(m => m.current == false).map((member) => {
-                            return (
-                                <div
-                                    key={member.name}
-                                    className="member relative mb-6 h-[90%] w-11/12 scale-0 rounded-lg bg-white p-4 shadow transition-all duration-500 md:p-8"
-                                >
-                                    <img
-                                        loading="lazy"
-                                        src={`assets/headshots/${member.image}`}
-                                        alt={member.name}
-                                        className="m-auto mb-4 h-20 w-20 rounded-full shadow lg:h-28 lg:w-28"
-                                    />
-                                    <p className="mb-2 text-center text-base font-semibold md:text-2xl">
-                                        {member.name}
-                                    </p>
-                                    <p
-                                        className={`hidden text-center text-gray-700 md:block
-                                    ${member.name ===
-                                                'Angelica Castillejos' ||
-                                                member.name ===
-                                                'Tasman Rosenfeld'
-                                                ? 'text-sm'
-                                                : 'text-base'
-                                            }`}
-                                    >
-                                        {member.about}
-                                    </p>
-                                </div>
-                            )
-                        })}
-                    </div>
-                </div>
-            </main>
-        </div>
+      },
+      {
+        threshold: 0.85,
+      }
     )
+
+    member_elements.forEach((member) => {
+      observor.observe(member)
+    })
+  }, [])
+
+  return (
+    <div>
+      <Head>
+        <title>About Us | SciTeens</title>
+        <link rel="icon" href="/favicon.ico" />
+        <meta
+          name="description"
+          content="SciTeens About Page"
+        />
+        <meta
+          name="keywords"
+          content="SciTeens, sciteens, science, teen science"
+        />
+        <meta property="og:type" content="website" />
+        <meta
+          name="og:image"
+          content="/assets/sciteens_initials.jpg"
+        />
+      </Head>
+      <main>
+        <div className="mx-auto w-full px-4 py-8 text-left md:p-8 lg:w-5/6">
+          <h1 className="my-4 text-center text-3xl font-semibold md:text-5xl">
+            {t('about.on_a_mission')}
+          </h1>
+          <p className="mx-0 mb-12 text-center text-base md:text-xl lg:mx-24">
+            {t('about.we_strive')}
+          </p>
+          <div className="mb-8 inline-grid h-full w-full grid-cols-2 place-items-center lg:grid-cols-3">
+            {members
+              .filter((m) => m.current == true)
+              .map((member) => {
+                return (
+                  <div
+                    key={member.name}
+                    className="member relative mb-6 h-[90%] w-11/12 scale-0 rounded-lg bg-white p-4 shadow transition-all duration-500 md:p-8"
+                  >
+                    <img
+                      loading="lazy"
+                      src={`assets/headshots/${member.image}`}
+                      alt={member.name}
+                      className="m-auto mb-4 h-20 w-20 rounded-full shadow lg:h-28 lg:w-28"
+                    />
+                    <p className="mb-2 text-center text-base font-semibold md:text-2xl">
+                      {member.name}
+                    </p>
+                    <p
+                      className={`hidden text-center text-gray-700 md:block
+                                    ${
+                                      member.name ===
+                                        'Angelica Castillejos' ||
+                                      member.name ===
+                                        'Tasman Rosenfeld'
+                                        ? 'text-sm'
+                                        : 'text-base'
+                                    }`}
+                    >
+                      {member.about}
+                    </p>
+                  </div>
+                )
+              })}
+          </div>
+
+          <h2 className="mb-6 text-center text-2xl font-bold md:text-3xl">
+            Previous Members
+          </h2>
+          <div className="mb-8 inline-grid h-full w-full grid-cols-2 place-items-center lg:grid-cols-3">
+            {members
+              .filter((m) => m.current == false)
+              .map((member) => {
+                return (
+                  <div
+                    key={member.name}
+                    className="member relative mb-6 h-[90%] w-11/12 scale-0 rounded-lg bg-white p-4 shadow transition-all duration-500 md:p-8"
+                  >
+                    <img
+                      loading="lazy"
+                      src={`assets/headshots/${member.image}`}
+                      alt={member.name}
+                      className="m-auto mb-4 h-20 w-20 rounded-full shadow lg:h-28 lg:w-28"
+                    />
+                    <p className="mb-2 text-center text-base font-semibold md:text-2xl">
+                      {member.name}
+                    </p>
+                    <p
+                      className={`hidden text-center text-gray-700 md:block
+                                    ${
+                                      member.name ===
+                                        'Angelica Castillejos' ||
+                                      member.name ===
+                                        'Tasman Rosenfeld'
+                                        ? 'text-sm'
+                                        : 'text-base'
+                                    }`}
+                    >
+                      {member.about}
+                    </p>
+                  </div>
+                )
+              })}
+          </div>
+        </div>
+      </main>
+    </div>
+  )
 }
 
 export async function getStaticProps({ locale }) {
-    return {
-        props: {
-            ...(await serverSideTranslations(locale, ['common'])),
-            // Will be passed to the page component as props
-        },
-    }
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common'])),
+      // Will be passed to the page component as props
+    },
+  }
 }

--- a/pages/article/[slug].js
+++ b/pages/article/[slug].js
@@ -13,10 +13,9 @@ import { useTranslation } from 'next-i18next'
 import { logEvent, getAnalytics } from 'firebase/analytics'
 
 function Article({ article, recommendations }) {
-  const [leftVisible, setLeftVisible] = useState(false)
-  const [rightVisible, setRightVisible] = useState(true)
+  const [, setLeftVisible] = useState(false)
+  const [, setRightVisible] = useState(true)
   const [scrollIndex, setScrollIndex] = useState(-1)
-  const [swipePosition, setSwipePositon] = useState(0)
   const [vote, setVote] = useState(null)
   const isAmp = false
   const { t } = useTranslation('common')
@@ -122,37 +121,6 @@ function Article({ article, recommendations }) {
     }
   }
 
-  const handleSwipe = (e, call) => {
-    if (call == 'start') {
-      setSwipePositon(e.touches[0].clientX)
-    } else {
-      const touchDown = swipePosition
-
-      if (touchDown == 0) {
-        return
-      }
-
-      const currentTouch = e.touches[0].clientX
-      const diff = touchDown - currentTouch
-
-      if (diff > 5) {
-        element.scrollTo(0, 0)
-        setScrollIndex(-1)
-      }
-
-      if (diff < -5 && scrollIndex > -1) {
-        element.scrollTo(
-          document.getElementById('i-' + (scrollIndex + 1))
-            ?.offsetLeft,
-          0
-        )
-        setScrollIndex(scrollIndex + 1)
-      }
-
-      setTouchPosition(null)
-    }
-  }
-
   const about_the_author = article.data.body.map(
     (slice, index) => {
       if (slice.slice_type == 'about_the_author') {
@@ -179,64 +147,59 @@ function Article({ article, recommendations }) {
     }
   )
 
-  const interviews = article.data.body.map(
-    (slice, index) => {
-      if (slice.slice_type == 'interview') {
-        return (
-          <>
-            <h3>{t('article.interview')}</h3>
-            {slice.items.map((interview, ix) => {
-              return (
-                <div key={ix} className="inline-block">
-                  <div className="flex flex-col items-center lg:flex-row">
-                    <Image
-                      className="h-20 w-20 rounded-full"
-                      height="64"
-                      width="64"
-                      loader={imageLoader}
-                      src={interview.headshot.url}
-                    />
-                    <h4
-                      className="ml-4"
-                      style={{
-                        marginTop: 0,
-                        marginBottom: 0,
-                      }}
-                    >
-                      {RichText.asText(
-                        interview.information
-                      )}
-                    </h4>
-                  </div>
-                  {RichText.render(interview.interview)}
+  const interviews = article.data.body.map((slice) => {
+    if (slice.slice_type == 'interview') {
+      return (
+        <>
+          <h3>{t('article.interview')}</h3>
+          {slice.items.map((interview, ix) => {
+            return (
+              <div key={ix} className="inline-block">
+                <div className="flex flex-col items-center lg:flex-row">
+                  <Image
+                    className="h-20 w-20 rounded-full"
+                    height="64"
+                    width="64"
+                    loader={imageLoader}
+                    src={interview.headshot.url}
+                  />
+                  <h4
+                    className="ml-4"
+                    style={{
+                      marginTop: 0,
+                      marginBottom: 0,
+                    }}
+                  >
+                    {RichText.asText(interview.information)}
+                  </h4>
                 </div>
-              )
-            })}
-          </>
-        )
-      } else {
-        return null
-      }
+                {RichText.render(interview.interview)}
+              </div>
+            )
+          })}
+        </>
+      )
+    } else {
+      return null
     }
-  )
+  })
 
-  const author_image = article.data.body.map(
-    (slice, index) => {
-      if (slice.slice_type == 'about_the_author') {
-        return (
-          <Image
-            className="rounded-full"
-            height="48"
-            width="48"
-            loader={imageLoader}
-            src={slice.primary.headshot.url}
-          />
-        )
-      } else {
-        return null
-      }
+  const author_image = article.data.body.map((slice) => {
+    if (slice.slice_type == 'about_the_author') {
+      return (
+        <Image
+          key={slice.primary.headshot.url}
+          className="rounded-full"
+          height="48"
+          width="48"
+          loader={imageLoader}
+          src={slice.primary.headshot.url}
+        />
+      )
+    } else {
+      return null
     }
-  )
+  })
 
   const recommendationsRendered = recommendations.map(
     (a, index) => {
@@ -336,6 +299,7 @@ function Article({ article, recommendations }) {
                   {article.tags.map((tag) => {
                     return (
                       <Link
+                        key={tag}
                         href={{
                           pathname: '/articles',
                           query: { field: tag },
@@ -380,9 +344,7 @@ function Article({ article, recommendations }) {
                           ? 'border-green-500 text-green-500'
                           : 'border-gray-600 text-gray-600'
                       }`}
-                      onClick={(e) =>
-                        handleRate('positive')
-                      }
+                      onClick={() => handleRate('positive')}
                     >
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
@@ -398,9 +360,7 @@ function Article({ article, recommendations }) {
                           ? 'border-red-500 text-red-500'
                           : 'border-gray-600 text-gray-600'
                       }`}
-                      onClick={(e) =>
-                        handleRate('negative')
-                      }
+                      onClick={() => handleRate('negative')}
                     >
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
@@ -465,6 +425,7 @@ function Article({ article, recommendations }) {
               {new Array(5).fill(1).map((data, i) => {
                 return (
                   <button
+                    key={i}
                     onClick={(e) => scroll(e, null, i)}
                     className={`h-[10px] w-[10px] rounded-full border border-black ${
                       scrollIndex == i - 1

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -22,7 +22,7 @@ import ReactPaginate from 'react-paginate'
 function Articles({ cached_articles }) {
   const router = useRouter()
   const [articles, setArticles] = useState(cached_articles)
-  const [page, setPage] = useState(0)
+  const [, setPage] = useState(0)
 
   useEffect(async () => {
     let isSubscribed = true
@@ -186,7 +186,7 @@ function Articles({ cached_articles }) {
   const articlesComponent = articles.results.map(
     (article, index) => {
       const author_image = article.data.body.map(
-        (slice, ix) => {
+        (slice) => {
           if (slice.slice_type == 'about_the_author') {
             return (
               <div

--- a/pages/course/[slug].js
+++ b/pages/course/[slug].js
@@ -1,6 +1,5 @@
 import { RichText } from 'prismic-reactjs'
 var Prismic = require('@prismicio/client')
-import Link from 'next/link'
 import moment from 'moment'
 import Image from 'next/image'
 import Head from 'next/head'
@@ -28,7 +27,7 @@ function Course({ course }) {
         const url = r.file.url
         const xhr = new XMLHttpRequest()
         xhr.responseType = 'blob'
-        xhr.onload = (e) => {
+        xhr.onload = () => {
           const blob = xhr.response
           if (xhr.status == 200) {
             console.log(blob)
@@ -70,6 +69,7 @@ function Course({ course }) {
               <a
                 href={slice.primary.lesson_link.url}
                 target="_blank"
+                rel="noreferrer"
               >
                 View
               </a>

--- a/pages/courses.js
+++ b/pages/courses.js
@@ -138,60 +138,51 @@ function Courses({ cached_courses }) {
     config: config.slow,
   }))
 
-  const coursesComponent = courses.results.map(
-    (course, index) => {
-      let courseStart = moment(course.data.start).format(
-        'll'
+  const coursesComponent = courses.results.map((course) => {
+    let courseStart = moment(course.data.start).format('ll')
+    let dateDisplay = <p></p>
+    if (courseStart == 'Invalid date') {
+      dateDisplay = (
+        <p className="flex text-xs">Asynchronous Course</p>
       )
-      let dateDisplay = <p></p>
-      if (courseStart == 'Invalid date') {
-        dateDisplay = (
-          <p className="flex text-xs">
-            Asynchronous Course
-          </p>
-        )
-      } else {
-        dateDisplay = (
-          <p className="flex text-xs">
-            {courseStart +
-              ' - ' +
-              moment(course.data.end).format('ll')}
-          </p>
-        )
-      }
-
-      return (
-        <Link
-          key={course.uid}
-          href={`/course/${course.uid}`}
-        >
-          <animated.div
-            style={courses_spring}
-            className="z-50 mt-6 flex cursor-pointer items-center rounded-lg bg-white p-4 shadow md:mt-8"
-          >
-            <div className="relative h-full max-w-[100px] md:max-w-[200px]">
-              <Image
-                className="flex-shrink-0 rounded-lg object-cover"
-                loader={imageLoader}
-                src={course.data.image_main.url}
-                width={256}
-                height={256}
-              />
-            </div>
-            <div className="ml-4 w-3/4 lg:w-11/12">
-              <h3 className="mb-2 text-base font-semibold line-clamp-2 md:text-xl lg:text-2xl">
-                {RichText.asText(course.data.name)}
-              </h3>
-              <p className="mb-2 hidden line-clamp-none md:block md:line-clamp-2 lg:line-clamp-3">
-                {RichText.asText(course.data.description)}
-              </p>
-              {dateDisplay}
-            </div>
-          </animated.div>
-        </Link>
+    } else {
+      dateDisplay = (
+        <p className="flex text-xs">
+          {courseStart +
+            ' - ' +
+            moment(course.data.end).format('ll')}
+        </p>
       )
     }
-  )
+
+    return (
+      <Link key={course.uid} href={`/course/${course.uid}`}>
+        <animated.div
+          style={courses_spring}
+          className="z-50 mt-6 flex cursor-pointer items-center rounded-lg bg-white p-4 shadow md:mt-8"
+        >
+          <div className="relative h-full max-w-[100px] md:max-w-[200px]">
+            <Image
+              className="flex-shrink-0 rounded-lg object-cover"
+              loader={imageLoader}
+              src={course.data.image_main.url}
+              width={256}
+              height={256}
+            />
+          </div>
+          <div className="ml-4 w-3/4 lg:w-11/12">
+            <h3 className="mb-2 text-base font-semibold line-clamp-2 md:text-xl lg:text-2xl">
+              {RichText.asText(course.data.name)}
+            </h3>
+            <p className="mb-2 hidden line-clamp-none md:block md:line-clamp-2 lg:line-clamp-3">
+              {RichText.asText(course.data.description)}
+            </p>
+            {dateDisplay}
+          </div>
+        </animated.div>
+      </Link>
+    )
+  })
   return (
     <>
       <Head>

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -34,6 +34,7 @@ export default function Donate() {
               href="https://www.paypal.com/donate?hosted_button_id=7B8QACYV83ACA"
               target="_blank"
               className="mr-2 rounded-lg bg-blue-500 p-2 text-white shadow-md hover:bg-blue-600"
+              rel="noreferrer"
             >
               {t('donate.donate_now')}
             </a>

--- a/pages/educators.js
+++ b/pages/educators.js
@@ -67,6 +67,7 @@ export default function Educators() {
               target="_blank"
               href="mailto:carlos@sciteens.com"
               className="font-semibold text-sciteensLightGreen-regular hover:text-sciteensLightGreen-dark"
+              rel="noreferrer"
             >
               Carlos Mercado-Lara
             </a>
@@ -77,6 +78,7 @@ export default function Educators() {
               target="_blank"
               href="mailto:aarti@sciteens.com"
               className="font-semibold text-sciteensLightGreen-regular hover:text-sciteensLightGreen-dark"
+              rel="noreferrer"
             >
               Aarti Kalamangalam
             </a>

--- a/pages/getinvolved.js
+++ b/pages/getinvolved.js
@@ -58,6 +58,7 @@ export default function GetInvolved() {
                   href="mailto:opportunities@sciteens.com"
                   target="_blank"
                   className="text-blue-700"
+                  rel="noreferrer"
                 >
                   &nbsp;opportunities@sciteens.com.&nbsp;
                 </a>
@@ -89,6 +90,7 @@ export default function GetInvolved() {
                   href="mailto:support@sciteens.com"
                   target="_blank"
                   className="text-blue-700"
+                  rel="noreferrer"
                 >
                   &nbsp;opportunities@sciteens.com.&nbsp;
                 </a>
@@ -97,6 +99,7 @@ export default function GetInvolved() {
                 href="mailto:support@sciteens.com"
                 target="_blank"
                 className="rounded-lg bg-sciteensLightGreen-regular p-2 text-center text-white shadow-md hover:bg-sciteensLightGreen-dark"
+                rel="noreferrer"
               >
                 {t('get_involved.contact_us')}
               </a>
@@ -122,6 +125,7 @@ export default function GetInvolved() {
                   href="mailto:support@sciteens.com"
                   target="_blank"
                   className="text-blue-700"
+                  rel="noreferrer"
                 >
                   &nbsp;opportunities@sciteens.com.&nbsp;
                 </a>
@@ -131,6 +135,7 @@ export default function GetInvolved() {
                 href="https://www.paypal.com/donate?hosted_button_id=7B8QACYV83ACA"
                 target="_blank"
                 className="mr-2 rounded-lg bg-blue-500 p-2 text-white shadow-md hover:bg-blue-600"
+                rel="noreferrer"
               >
                 {t('get_involved.donate_now')}
               </a>

--- a/pages/legal/gdpr.js
+++ b/pages/legal/gdpr.js
@@ -1,9 +1,7 @@
 import Head from 'next/head'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { useTranslation } from 'next-i18next'
 
 export default function gdpr() {
-  const { t } = useTranslation('common')
   return (
     <div>
       <Head>
@@ -94,16 +92,17 @@ export default function gdpr() {
             </p>
             <p className="mb-10 text-gray-700">
               This Cookie Policy explains how SciTeens Inc.
-              ("Company", "we", "us", and "our") uses
+              (&quot;Company&quot;, &quot;we&quot;,
+              &quot;us&quot;, and &quot;our&quot;) uses
               cookies and similar technologies to recognize
               you when you visit our websites at
-              http://sciteens.com, ("Websites"). It explains
-              what these technologies are and why we use
-              them, as well as your rights to control our
-              use of them. In some cases we may use cookies
-              to collect personal information, or that
-              becomes personal information if we combine it
-              with other information.
+              http://sciteens.com, (&quot;Websites&quot;).
+              It explains what these technologies are and
+              why we use them, as well as your rights to
+              control our use of them. In some cases we may
+              use cookies to collect personal information,
+              or that becomes personal information if we
+              combine it with other information.
             </p>
 
             {/* Policy 1 */}
@@ -119,18 +118,18 @@ export default function gdpr() {
                 websites work, or to work more efficiently,
                 as well as to provide reporting information.
                 Cookies set by the website owner (in this
-                case, SciTeens Inc.) are called "first party
-                cookies". Cookies set by parties other than
-                the website owner are called "third party
-                cookies". Third party cookies enable third
-                party features or functionality to be
-                provided on or through the website (e.g.
-                like advertising, interactive content and
-                analytics). The parties that set these third
-                party cookies can recognize your computer
-                both when it visits the website in question
-                and also when it visits certain other
-                websites.
+                case, SciTeens Inc.) are called &quot;first
+                party cookies&quot;. Cookies set by parties
+                other than the website owner are called
+                &quot;third party cookies&quot;. Third party
+                cookies enable third party features or
+                functionality to be provided on or through
+                the website (e.g. like advertising,
+                interactive content and analytics). The
+                parties that set these third party cookies
+                can recognize your computer both when it
+                visits the website in question and also when
+                it visits certain other websites.
               </p>
             </div>
 
@@ -144,20 +143,20 @@ export default function gdpr() {
                 several reasons. Some cookies are required
                 for technical reasons in order for our
                 Websites to operate, and we refer to these
-                as "essential" or "strictly necessary"
-                cookies. Other cookies also enable us to
-                track and target the interests of our users
-                to enhance the experience on our Online
-                Properties. Third parties serve cookies
-                through our Websites for advertising,
-                analytics and other purposes. This is
-                described in more detail below. The specific
-                types of first and third party cookies
-                served through our Websites and the purposes
-                they perform are described below (please
-                note that the specific cookies served may
-                vary depending on the specific Online
-                Properties you visit).
+                as &quot;essential&quot; or &quot;strictly
+                necessary&quot; cookies. Other cookies also
+                enable us to track and target the interests
+                of our users to enhance the experience on
+                our Online Properties. Third parties serve
+                cookies through our Websites for
+                advertising, analytics and other purposes.
+                This is described in more detail below. The
+                specific types of first and third party
+                cookies served through our Websites and the
+                purposes they perform are described below
+                (please note that the specific cookies
+                served may vary depending on the specific
+                Online Properties you visit).
               </p>
             </div>
 
@@ -186,8 +185,8 @@ export default function gdpr() {
                 refuse cookies. As the means by which you
                 can refuse cookies through your web browser
                 controls vary from browser-to-browser, you
-                should visit your browser's help menu for
-                more information. In addition, most
+                should visit your browser&apos;s help menu
+                for more information. In addition, most
                 advertising networks offer you a way to opt
                 out of targeted advertising. If you would
                 like to find out more information, please
@@ -238,10 +237,10 @@ export default function gdpr() {
                 track visitors to a website. We may use
                 other, similar technologies from time to
                 time, like web beacons (sometimes called
-                "tracking pixels" or "clear gifs"). These
-                are tiny graphics files that contain a
-                unique identifier that enable us to
-                recognize when someone has visited our
+                &quot;tracking pixels&quot; or &quot;clear
+                gifs&quot;). These are tiny graphics files
+                that contain a unique identifier that enable
+                us to recognize when someone has visited our
                 Websites or opened an e-mail including them.
                 This allows us, for example, to monitor the
                 traffic patterns of users from one page
@@ -266,35 +265,35 @@ export default function gdpr() {
                 OBJECTS?
               </h2>
               <p className="mb-10 text-gray-700">
-                Websites may also use so-called "Flash
-                Cookies" (also known as Local Shared Objects
-                or "LSOs") to, among other things, collect
-                and store information about your use of our
-                services, fraud prevention and for other
-                site operations. If you do not want Flash
-                Cookies stored on your computer, you can
-                adjust the settings of your Flash player to
-                block Flash Cookies storage using the tools
-                contained in the Website Storage Settings
-                Panel. You can also control Flash Cookies by
-                going to the Global Storage Settings Panel
-                and following the instructions (which may
-                include instructions that explain, for
-                example, how to delete existing Flash
-                Cookies (referred to "information" on the
-                Macromedia site), how to prevent Flash LSOs
-                from being placed on your computer without
-                your being asked, and (for Flash Player 8
-                and later) how to block Flash Cookies that
-                are not being delivered by the operator of
-                the page you are on at the time). Please
-                note that setting the Flash Player to
-                restrict or limit acceptance of Flash
-                Cookies may reduce or impede the
-                functionality of some Flash applications,
-                including, potentially, Flash applications
-                used in connection with our services or
-                online content.
+                Websites may also use so-called &quot;Flash
+                Cookies&quot; (also known as Local Shared
+                Objects or &quot;LSOs&quot;) to, among other
+                things, collect and store information about
+                your use of our services, fraud prevention
+                and for other site operations. If you do not
+                want Flash Cookies stored on your computer,
+                you can adjust the settings of your Flash
+                player to block Flash Cookies storage using
+                the tools contained in the Website Storage
+                Settings Panel. You can also control Flash
+                Cookies by going to the Global Storage
+                Settings Panel and following the
+                instructions (which may include instructions
+                that explain, for example, how to delete
+                existing Flash Cookies (referred to
+                &quot;information&quot; on the Macromedia
+                site), how to prevent Flash LSOs from being
+                placed on your computer without your being
+                asked, and (for Flash Player 8 and later)
+                how to block Flash Cookies that are not
+                being delivered by the operator of the page
+                you are on at the time). Please note that
+                setting the Flash Player to restrict or
+                limit acceptance of Flash Cookies may reduce
+                or impede the functionality of some Flash
+                applications, including, potentially, Flash
+                applications used in connection with our
+                services or online content.
               </p>
             </div>
 

--- a/pages/legal/privacy.js
+++ b/pages/legal/privacy.js
@@ -1,9 +1,7 @@
 import Head from 'next/head'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { useTranslation } from 'next-i18next'
 
 export default function privacy() {
-  const { t } = useTranslation('common')
   return (
     <div>
       <Head>
@@ -186,10 +184,11 @@ export default function privacy() {
               our website (such as https://sciteens.com),
               and/or any related services, sales, marketing
               or events (we refer to them collectively in
-              this privacy policy as the "Services"). Please
-              read this privacy policy carefully as it will
-              help you make informed decisions about sharing
-              your personal information with us.
+              this privacy policy as the
+              &quot;Services&quot;). Please read this
+              privacy policy carefully as it will help you
+              make informed decisions about sharing your
+              personal information with us.
             </p>
 
             {/* Privacy 1 */}
@@ -238,11 +237,11 @@ export default function privacy() {
                 like your Facebook, Twitter or other social
                 media account. If you choose to register in
                 this way, we will collect the information
-                described in the section called "HOW DO WE
-                HANDLE YOUR SOCIAL LOGINS" below. All
-                personal information that you provide to us
-                must be true, complete and accurate, and you
-                must notify us of any changes to such
+                described in the section called &quot;HOW DO
+                WE HANDLE YOUR SOCIAL LOGINS&quot; below.
+                All personal information that you provide to
+                us must be true, complete and accurate, and
+                you must notify us of any changes to such
                 personal information.
               </p>
 
@@ -345,14 +344,14 @@ export default function privacy() {
                   facilitate account creation and logon
                   process for the performance of the
                   contract. See the section below headed
-                  "HOW DO WE HANDLE YOUR SOCIAL LOGINS" for
-                  further information.
+                  &quot;HOW DO WE HANDLE YOUR SOCIAL
+                  LOGINS&quot; for further information.
                 </li>
                 <li>
                   To enable user-to-user communications. We
                   may use your information in order to
                   enable user-to-user communications with
-                  each user's consent.
+                  each user&apos;s consent.
                 </li>
                 <li>
                   To enforce our terms, conditions and

--- a/pages/legal/terms.js
+++ b/pages/legal/terms.js
@@ -1,9 +1,7 @@
 import Head from 'next/head'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { useTranslation } from 'next-i18next'
 
 export default function terms() {
-  const { t } = useTranslation('common')
   return (
     <div>
       <Head>
@@ -238,43 +236,44 @@ export default function terms() {
                 binding agreement made between you, whether
                 personally or on behalf of an entity (“you”)
                 and SciTeens Inc., doing business as
-                SciTeens ("SciTeens", “we”, “us”, or “our”),
-                concerning your access to and use of the
-                http://sciteens.com website as well as any
-                other media form, media channel, mobile
-                website or mobile application related,
-                linked, or otherwise connected thereto
-                (collectively, the “Site”). You agree that
-                by accessing the Site, you have read,
-                understood, and agreed to be bound by all of
-                these Terms of Use. IF YOU DO NOT AGREE WITH
-                ALL OF THESE TERMS OF USE, THEN YOU ARE
-                EXPRESSLY PROHIBITED FROM USING THE SITE AND
-                YOU MUST DISCONTINUE USE IMMEDIATELY.
-                Supplemental terms and conditions or
-                documents that may be posted on the Site
-                from time to time are hereby expressly
-                incorporated herein by reference. We reserve
-                the right, in our sole discretion, to make
-                changes or modifications to these Terms of
-                Use at any time and for any reason. We will
-                alert you about any changes by updating the
-                “Last updated” date of these Terms of Use,
-                and you waive any right to receive specific
-                notice of each such change. It is your
-                responsibility to periodically review these
-                Terms of Use to stay informed of updates.
-                You will be subject to, and will be deemed
-                to have been made aware of and to have
-                accepted, the changes in any revised Terms
-                of Use by your continued use of the Site
-                after the date such revised Terms of Use are
-                posted. The information provided on the Site
-                is not intended for distribution to or use
-                by any person or entity in any jurisdiction
-                or country where such distribution or use
-                would be contrary to law or regulation or
-                which would subject us to any registration
+                SciTeens (&quot;SciTeens&quot;, “we”, “us”,
+                or “our”), concerning your access to and use
+                of the http://sciteens.com website as well
+                as any other media form, media channel,
+                mobile website or mobile application
+                related, linked, or otherwise connected
+                thereto (collectively, the “Site”). You
+                agree that by accessing the Site, you have
+                read, understood, and agreed to be bound by
+                all of these Terms of Use. IF YOU DO NOT
+                AGREE WITH ALL OF THESE TERMS OF USE, THEN
+                YOU ARE EXPRESSLY PROHIBITED FROM USING THE
+                SITE AND YOU MUST DISCONTINUE USE
+                IMMEDIATELY. Supplemental terms and
+                conditions or documents that may be posted
+                on the Site from time to time are hereby
+                expressly incorporated herein by reference.
+                We reserve the right, in our sole
+                discretion, to make changes or modifications
+                to these Terms of Use at any time and for
+                any reason. We will alert you about any
+                changes by updating the “Last updated” date
+                of these Terms of Use, and you waive any
+                right to receive specific notice of each
+                such change. It is your responsibility to
+                periodically review these Terms of Use to
+                stay informed of updates. You will be
+                subject to, and will be deemed to have been
+                made aware of and to have accepted, the
+                changes in any revised Terms of Use by your
+                continued use of the Site after the date
+                such revised Terms of Use are posted. The
+                information provided on the Site is not
+                intended for distribution to or use by any
+                person or entity in any jurisdiction or
+                country where such distribution or use would
+                be contrary to law or regulation or which
+                would subject us to any registration
                 requirement within such jurisdiction or
                 country. Accordingly, those persons who
                 choose to access the Site from other
@@ -595,14 +594,14 @@ export default function terms() {
                 video, audio, photographs, graphics,
                 comments, suggestions, or personal
                 information or other material (collectively,
-                "Contributions"). Contributions may be
-                viewable by other users of the Site and
-                through third-party websites. As such, any
-                Contributions you transmit may be treated as
-                non-confidential and non-proprietary. When
-                you create or make available any
-                Contributions, you thereby represent and
-                warrant that:
+                &quot;Contributions&quot;). Contributions
+                may be viewable by other users of the Site
+                and through third-party websites. As such,
+                any Contributions you transmit may be
+                treated as non-confidential and
+                non-proprietary. When you create or make
+                available any Contributions, you thereby
+                represent and warrant that:
               </p>
               <ul className="mb-4 ml-4 list-inside list-decimal text-gray-700">
                 <li>
@@ -780,13 +779,13 @@ export default function terms() {
                 You acknowledge and agree that any
                 questions, comments, suggestions, ideas,
                 feedback, or other information regarding the
-                Site ("Submissions") provided by you to us
-                are non-confidential and shall become our
-                sole property. We shall own exclusive
-                rights, including all intellectual property
-                rights, and shall be entitled to the
-                unrestricted use and dissemination of these
-                Submissions for any lawful purpose,
+                Site (&quot;Submissions&quot;) provided by
+                you to us are non-confidential and shall
+                become our sole property. We shall own
+                exclusive rights, including all intellectual
+                property rights, and shall be entitled to
+                the unrestricted use and dissemination of
+                these Submissions for any lawful purpose,
                 commercial or otherwise, without
                 acknowledgment or compensation to you. You
                 hereby waive all moral rights to any such
@@ -808,55 +807,55 @@ export default function terms() {
               <p className="mb-10 text-gray-700">
                 The Site may contain (or you may be sent via
                 the Site) links to other websites
-                ("Third-Party Websites") as well as
-                articles, photographs, text, graphics,
+                (&quot;Third-Party Websites&quot;) as well
+                as articles, photographs, text, graphics,
                 pictures, designs, music, sound, video,
                 information, applications, software, and
                 other content or items belonging to or
-                originating from third parties ("Third-Party
-                Content"). Such Third-Party Websites and
-                Third-Party Content are not investigated,
-                monitored, or checked for accuracy,
-                appropriateness, or completeness by us, and
-                we are not responsible for any Third-Party
-                Websites accessed through the Site or any
-                Third-Party Content posted on, available
-                through, or installed from the Site,
-                including the content, accuracy,
-                offensiveness, opinions, reliability,
-                privacy practices, or other policies of or
-                contained in the Third-Party Websites or the
-                Third-Party Content. Inclusion of, linking
-                to, or permitting the use or installation of
-                any Third-Party Websites or any Third-Party
-                Content does not imply approval or
-                endorsement thereof by us. If you decide to
-                leave the Site and access the Third-Party
-                Websites or to use or install any
-                Third-Party Content, you do so at your own
-                risk, and you should be aware these Terms of
-                Use no longer govern. You should review the
-                applicable terms and policies, including
-                privacy and data gathering practices, of any
-                website to which you navigate from the Site
-                or relating to any applications you use or
-                install from the Site. Any purchases you
-                make through Third-Party Websites will be
-                through other websites and from other
-                companies, and we take no responsibility
-                whatsoever in relation to such purchases
-                which are exclusively between you and the
-                applicable third party. You agree and
-                acknowledge that we do not endorse the
-                products or services offered on Third-Party
-                Websites and you shall hold us harmless from
-                any harm caused by your purchase of such
-                products or services. Additionally, you
-                shall hold us harmless from any losses
-                sustained by you or harm caused to you
-                relating to or resulting in any way from any
-                Third-Party Content or any contact with
-                Third-Party Websites.
+                originating from third parties
+                (&quot;Third-Party Content&quot;). Such
+                Third-Party Websites and Third-Party Content
+                are not investigated, monitored, or checked
+                for accuracy, appropriateness, or
+                completeness by us, and we are not
+                responsible for any Third-Party Websites
+                accessed through the Site or any Third-Party
+                Content posted on, available through, or
+                installed from the Site, including the
+                content, accuracy, offensiveness, opinions,
+                reliability, privacy practices, or other
+                policies of or contained in the Third-Party
+                Websites or the Third-Party Content.
+                Inclusion of, linking to, or permitting the
+                use or installation of any Third-Party
+                Websites or any Third-Party Content does not
+                imply approval or endorsement thereof by us.
+                If you decide to leave the Site and access
+                the Third-Party Websites or to use or
+                install any Third-Party Content, you do so
+                at your own risk, and you should be aware
+                these Terms of Use no longer govern. You
+                should review the applicable terms and
+                policies, including privacy and data
+                gathering practices, of any website to which
+                you navigate from the Site or relating to
+                any applications you use or install from the
+                Site. Any purchases you make through
+                Third-Party Websites will be through other
+                websites and from other companies, and we
+                take no responsibility whatsoever in
+                relation to such purchases which are
+                exclusively between you and the applicable
+                third party. You agree and acknowledge that
+                we do not endorse the products or services
+                offered on Third-Party Websites and you
+                shall hold us harmless from any harm caused
+                by your purchase of such products or
+                services. Additionally, you shall hold us
+                harmless from any losses sustained by you or
+                harm caused to you relating to or resulting
+                in any way from any Third-Party Content or
+                any contact with Third-Party Websites.
               </p>
             </div>
 
@@ -1070,16 +1069,16 @@ export default function terms() {
                 To expedite resolution and control the cost
                 of any dispute, controversy, or claim
                 related to these Terms of Use (each a
-                "Dispute" and collectively, the “Disputes”)
-                brought by either you or us (individually, a
-                “Party” and collectively, the “Parties”),
-                the Parties agree to first attempt to
-                negotiate any Dispute (except those Disputes
-                expressly provided below) informally for at
-                least thirty (30) days before initiating
-                arbitration. Such informal negotiations
-                commence upon written notice from one Party
-                to the other Party.
+                &quot;Dispute&quot; and collectively, the
+                “Disputes”) brought by either you or us
+                (individually, a “Party” and collectively,
+                the “Parties”), the Parties agree to first
+                attempt to negotiate any Dispute (except
+                those Disputes expressly provided below)
+                informally for at least thirty (30) days
+                before initiating arbitration. Such informal
+                negotiations commence upon written notice
+                from one Party to the other Party.
               </p>
               <p className="mb-2 text-lg">
                 Binding Arbitration
@@ -1095,42 +1094,43 @@ export default function terms() {
                 SUE IN COURT AND HAVE A JURY TRIAL. The
                 arbitration shall be commenced and conducted
                 under the Commercial Arbitration Rules of
-                the American Arbitration Association ("AAA")
-                and, where appropriate, the AAA’s
-                Supplementary Procedures for Consumer
-                Related Disputes ("AAA Consumer Rules"),
-                both of which are available at the AAA
-                website: www.adr.org. Your arbitration fees
-                and your share of arbitrator compensation
-                shall be governed by the AAA Consumer Rules
-                and, where appropriate, limited by the AAA
-                Consumer Rules. The arbitration may be
-                conducted in person, through the submission
-                of documents, by phone, or online. The
-                arbitrator will make a decision in writing,
-                but need not provide a statement of reasons
-                unless requested by either Party. The
-                arbitrator must follow applicable law, and
-                any award may be challenged if the
-                arbitrator fails to do so. Except where
-                otherwise required by the applicable AAA
-                rules or applicable law, the arbitration
-                will take place in Leon, Florida. Except as
-                otherwise provided herein, the Parties may
-                litigate in court to compel arbitration,
-                stay proceedings pending arbitration, or to
-                confirm, modify, vacate, or enter judgment
-                on the award entered by the arbitrator. If
-                for any reason, a Dispute proceeds in court
-                rather than arbitration, the Dispute shall
-                be commenced or prosecuted in the state and
-                federal courts located in Leon, Florida, and
-                the Parties hereby consent to, and waive all
-                defenses of lack of personal jurisdiction,
-                and forum non conveniens with respect to
-                venue and jurisdiction in such state and
-                federal courts. Application of the United
-                Nations Convention on Contracts for the
+                the American Arbitration Association
+                (&quot;AAA&quot;) and, where appropriate,
+                the AAA’s Supplementary Procedures for
+                Consumer Related Disputes (&quot;AAA
+                Consumer Rules&quot;), both of which are
+                available at the AAA website: www.adr.org.
+                Your arbitration fees and your share of
+                arbitrator compensation shall be governed by
+                the AAA Consumer Rules and, where
+                appropriate, limited by the AAA Consumer
+                Rules. The arbitration may be conducted in
+                person, through the submission of documents,
+                by phone, or online. The arbitrator will
+                make a decision in writing, but need not
+                provide a statement of reasons unless
+                requested by either Party. The arbitrator
+                must follow applicable law, and any award
+                may be challenged if the arbitrator fails to
+                do so. Except where otherwise required by
+                the applicable AAA rules or applicable law,
+                the arbitration will take place in Leon,
+                Florida. Except as otherwise provided
+                herein, the Parties may litigate in court to
+                compel arbitration, stay proceedings pending
+                arbitration, or to confirm, modify, vacate,
+                or enter judgment on the award entered by
+                the arbitrator. If for any reason, a Dispute
+                proceeds in court rather than arbitration,
+                the Dispute shall be commenced or prosecuted
+                in the state and federal courts located in
+                Leon, Florida, and the Parties hereby
+                consent to, and waive all defenses of lack
+                of personal jurisdiction, and forum non
+                conveniens with respect to venue and
+                jurisdiction in such state and federal
+                courts. Application of the United Nations
+                Convention on Contracts for the
                 International Sale of Goods and the the
                 Uniform Computer Information Transaction Act
                 (UCITA) is excluded from these Terms of Use.

--- a/pages/profile/[slug]/edit.js
+++ b/pages/profile/[slug]/edit.js
@@ -48,8 +48,7 @@ export default function UpdateProfilePage({
   const { t } = useTranslation('common')
   const [loading, setLoading] = useState(false)
   const [about, setAbout] = useState('')
-  const [member, setMember] = useState('')
-  const [members, setMembers] = useState([])
+  const [members] = useState([])
   const [file_extensions] = useState([
     'text/html',
     'image/png',
@@ -71,7 +70,6 @@ export default function UpdateProfilePage({
   const [profile_photo, setProfilePhoto] = useState(null)
 
   const [error_about, setErrorAbout] = useState('')
-  const [error_member, setErrorMember] = useState('')
   const [error_file, setErrorFile] = useState('')
 
   const { status, data: signInCheckResult } =
@@ -142,9 +140,8 @@ export default function UpdateProfilePage({
   const updateProfile = async (e) => {
     e.preventDefault()
     setLoading(true)
-    let res
     try {
-      res = await updateDoc(
+      await updateDoc(
         doc(firestore, 'profiles', user_profile.id),
         {
           about: about.trim(),
@@ -232,12 +229,8 @@ export default function UpdateProfilePage({
     }
   })
 
-  const {
-    acceptedFiles,
-    getRootProps,
-    getInputProps,
-    isDragActive,
-  } = useDropzone({ onDrop })
+  const { getRootProps, getInputProps, isDragActive } =
+    useDropzone({ onDrop })
 
   async function onChange(e, target) {
     switch (target) {
@@ -256,7 +249,7 @@ export default function UpdateProfilePage({
     e.preventDefault()
     let temp_files = [...files]
     let temp_metadata = [...metadata_arr]
-    const removed_file = temp_files.splice(id, 1)
+    temp_files.splice(id, 1)
     const removed_metadata = temp_metadata.splice(id, 1)
     setFiles([...temp_files])
     setMetadata([...temp_metadata])
@@ -284,7 +277,7 @@ export default function UpdateProfilePage({
           </p>
           <form onSubmit={(e) => updateProfile(e)}>
             <label
-              for="about"
+              htmlFor="about"
               className="uppercase text-gray-600"
             >
               {t('edit_profile.about')}
@@ -310,20 +303,7 @@ export default function UpdateProfilePage({
             </p>
 
             {members.map((m, index) => (
-              <p className="p-2">
-                <button
-                  name={index}
-                  className="mr-2 h-3 w-3 fill-current hover:text-red-900"
-                  onClick={(e) => removeMember(e)}
-                >
-                  <svg
-                    name={index}
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 20 20"
-                  >
-                    <path d="M10 8.586L2.929 1.515 1.515 2.929 8.586 10l-7.071 7.071 1.414 1.414L10 11.414l7.071 7.071 1.414-1.414L11.414 10l7.071-7.071-1.414-1.414L10 8.586z" />
-                  </svg>
-                </button>
+              <p key={index} className="p-2">
                 {m}
               </p>
             ))}
@@ -362,7 +342,7 @@ export default function UpdateProfilePage({
             </div>
             {profile_photo && (
               <label
-                for="project_photo"
+                htmlFor="project_photo"
                 className="mt-2 uppercase text-gray-600"
               >
                 {t('edit_profile.profile_photo')}

--- a/pages/profile/[slug]/index.js
+++ b/pages/profile/[slug]/index.js
@@ -1,7 +1,6 @@
 import { useEffect, useState, useContext } from 'react'
 
 import Head from 'next/head'
-import Error from 'next/error'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import ProfilePhoto from '../../../components/ProfilePhoto'
@@ -9,7 +8,6 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
 
 import {
-  doc,
   getDocs,
   getFirestore,
   query as firebase_query,
@@ -84,7 +82,7 @@ function Project({ profile }) {
         const metadata = await getMetadata(r)
         const xhr = new XMLHttpRequest()
         xhr.responseType = 'blob'
-        xhr.onload = (e) => {
+        xhr.onload = () => {
           const blob = xhr.response
           if (xhr.status == 200) {
             blob.name = metadata.name
@@ -101,7 +99,7 @@ function Project({ profile }) {
 
   useEffect(() => {}, [status])
 
-  const [project_spring, set] = useSpring(() => ({
+  const [project_spring] = useSpring(() => ({
     opacity: 1,
     transform: 'translateX(0)',
     from: {
@@ -125,103 +123,99 @@ function Project({ profile }) {
     } else return 3
   }
 
-  const projectsComponent = projects.map(
-    (project, index) => {
-      return (
-        <Link
-          key={project.id}
-          href={`/project/${project.id}`}
+  const projectsComponent = projects.map((project) => {
+    return (
+      <Link
+        key={project.id}
+        href={`/project/${project.id}`}
+      >
+        <animated.a
+          style={project_spring}
+          className="z-50 mt-6 flex cursor-pointer items-center overflow-hidden rounded-lg bg-white p-4 shadow md:mt-8"
         >
-          <animated.a
-            style={project_spring}
-            className="z-50 mt-6 flex cursor-pointer items-center overflow-hidden rounded-lg bg-white p-4 shadow md:mt-8"
-          >
-            <div className="relative h-full max-h-[100px] max-w-[100px] overflow-hidden rounded-lg md:max-h-[200px] md:max-w-[200px]">
-              <img
-                src={
-                  project.project_photo
-                    ? project.project_photo
-                    : ''
-                }
-                className="rounded-lg object-cover"
-              ></img>
-            </div>
-            <div className="ml-4 w-3/4 lg:w-11/12">
-              {project.member_arr && (
-                <div className="mb-3 flex flex-row items-center">
-                  <div className="flex -space-x-2 overflow-hidden">
-                    {project.member_arr.map(
-                      (member, index) => {
-                        return (
-                          <div
-                            key={index}
-                            className="inline-block h-6 w-6 rounded-full ring-2 ring-white lg:h-8 lg:w-8"
-                          >
-                            <ProfilePhoto
-                              uid={member.uid}
-                            ></ProfilePhoto>
-                          </div>
-                        )
-                      }
-                    )}
-                  </div>
-                  <p className="ml-2">
-                    By{' '}
-                    {project.member_arr.map((member) => {
-                      return member.display + ' '
-                    })}
-                  </p>
+          <div className="relative h-full max-h-[100px] max-w-[100px] overflow-hidden rounded-lg md:max-h-[200px] md:max-w-[200px]">
+            <img
+              src={
+                project.project_photo
+                  ? project.project_photo
+                  : ''
+              }
+              className="rounded-lg object-cover"
+              alt=""
+            ></img>
+          </div>
+          <div className="ml-4 w-3/4 lg:w-11/12">
+            {project.member_arr && (
+              <div className="mb-3 flex flex-row items-center">
+                <div className="flex -space-x-2 overflow-hidden">
+                  {project.member_arr.map(
+                    (member, index) => {
+                      return (
+                        <div
+                          key={index}
+                          className="inline-block h-6 w-6 rounded-full ring-2 ring-white lg:h-8 lg:w-8"
+                        >
+                          <ProfilePhoto
+                            uid={member.uid}
+                          ></ProfilePhoto>
+                        </div>
+                      )
+                    }
+                  )}
                 </div>
-              )}
-              <h3 className="mb-2 text-base font-semibold line-clamp-2 md:text-xl lg:text-2xl">
-                {project.title}
-              </h3>
-              <p className="mb-4 hidden line-clamp-none md:block md:line-clamp-2 lg:line-clamp-3">
-                {project.abstract}
-              </p>
-              <div className="hidden flex-row lg:flex">
-                {project.fields.map((field, index) => {
-                  if (
-                    index <
-                    checkForLongFields(project.fields)
-                  )
-                    return (
-                      <p
-                        key={index}
-                        className="z-30 mr-2 mb-2 whitespace-nowrap rounded-full bg-gray-100 py-1.5 px-3 text-xs shadow"
-                      >
-                        {getTranslatedFieldsDict(t)[field]}
-                      </p>
-                    )
-                })}
-                {project.fields.length >= 3 && (
-                  <p className="mt-1.5 hidden whitespace-nowrap text-xs text-gray-600 lg:flex">
-                    +{' '}
-                    {project.fields.length -
-                      checkForLongFields(
-                        project.fields
-                      )}{' '}
-                    more field
-                    {project.fields.length -
-                      checkForLongFields(project.fields) ==
-                    1
-                      ? ''
-                      : 's'}
-                  </p>
-                )}
+                <p className="ml-2">
+                  By{' '}
+                  {project.member_arr.map((member) => {
+                    return member.display + ' '
+                  })}
+                </p>
               </div>
+            )}
+            <h3 className="mb-2 text-base font-semibold line-clamp-2 md:text-xl lg:text-2xl">
+              {project.title}
+            </h3>
+            <p className="mb-4 hidden line-clamp-none md:block md:line-clamp-2 lg:line-clamp-3">
+              {project.abstract}
+            </p>
+            <div className="hidden flex-row lg:flex">
+              {project.fields.map((field, index) => {
+                if (
+                  index < checkForLongFields(project.fields)
+                )
+                  return (
+                    <p
+                      key={index}
+                      className="z-30 mr-2 mb-2 whitespace-nowrap rounded-full bg-gray-100 py-1.5 px-3 text-xs shadow"
+                    >
+                      {getTranslatedFieldsDict(t)[field]}
+                    </p>
+                  )
+              })}
+              {project.fields.length >= 3 && (
+                <p className="mt-1.5 hidden whitespace-nowrap text-xs text-gray-600 lg:flex">
+                  +{' '}
+                  {project.fields.length -
+                    checkForLongFields(project.fields)}{' '}
+                  more field
+                  {project.fields.length -
+                    checkForLongFields(project.fields) ==
+                  1
+                    ? ''
+                    : 's'}
+                </p>
+              )}
             </div>
-          </animated.a>
-        </Link>
-      )
-    }
-  )
+          </div>
+        </animated.a>
+      </Link>
+    )
+  })
 
   return (
     <>
       <Head>
         <title>
-          {profile.display}'s Profile | SciTeens
+          {profile.display}&apos;s Profile | SciTeens
         </title>
         <link rel="icon" href="/favicon.ico" />
         <meta
@@ -252,7 +246,6 @@ function Project({ profile }) {
       </Head>
       <div className="mx-auto mt-12 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
         <div>
-          <h1></h1>
           <div className="m-0 flex flex-row justify-between p-0 leading-none">
             <div className="mb-8 flex flex-row items-center">
               <div className="h-18 w-18 mr-5">
@@ -317,7 +310,7 @@ function Project({ profile }) {
           projectsComponent
         ) : (
           <p className="text-gray-500">
-            This user hasn't created any projects yet
+            This user hasn&apos;t created any projects yet
           </p>
         )}
       </div>

--- a/pages/project/[id]/edit.js
+++ b/pages/project/[id]/edit.js
@@ -2,10 +2,8 @@ import React, {
   useState,
   useCallback,
   useEffect,
-  useReducer,
 } from 'react'
 
-import Head from 'next/head'
 import Error from 'next/error'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
@@ -24,6 +22,7 @@ import {
   orderBy,
   limit,
   getDoc,
+  getDocs,
   doc,
   updateDoc,
   setDoc,
@@ -43,7 +42,6 @@ import isEmail from 'validator/lib/isEmail'
 import debounce from 'lodash.debounce'
 import { useDropzone } from 'react-dropzone'
 import File from '../../../components/File'
-import { getFluidObservers } from '@react-spring/shared'
 import {
   getTranslatedFieldsDict,
   sanitizeFileName,
@@ -314,12 +312,8 @@ export default function UpdateProject({ query }) {
     }
   })
 
-  const {
-    acceptedFiles,
-    getRootProps,
-    getInputProps,
-    isDragActive,
-  } = useDropzone({ onDrop })
+  const { getRootProps, getInputProps, isDragActive } =
+    useDropzone({ onDrop })
 
   async function onChange(e, target) {
     switch (target) {
@@ -379,7 +373,7 @@ export default function UpdateProject({ query }) {
         }
         break
 
-      case 'fields':
+      case 'fields': {
         const id = e.target.id
         const index = Object.keys(
           getTranslatedFieldsDict(t)
@@ -387,6 +381,7 @@ export default function UpdateProject({ query }) {
         let temp = [...field_values]
         temp[index] = !temp[index]
         setFieldValues([...temp])
+      }
     }
   }
 
@@ -605,7 +600,7 @@ export default function UpdateProject({ query }) {
                 {error_member}
               </p>
               {members.map((m, index) => (
-                <p className="p-2">
+                <p className="p-2" key={index}>
                   <button
                     name={index}
                     className="mr-2 h-3 w-3 fill-current hover:text-red-900"
@@ -633,7 +628,7 @@ export default function UpdateProject({ query }) {
                 getTranslatedFieldsDict(t)
               ).map(([key, value], index) => {
                 return (
-                  <div>
+                  <div key={key}>
                     <input
                       id={key}
                       className="form-checkbox active:outline-none mr-2 text-sciteensLightGreen-regular"
@@ -645,7 +640,7 @@ export default function UpdateProject({ query }) {
                       }
                     />
                     <label
-                      for={key}
+                      htmlFor={key}
                       className="text-gray-700"
                     >
                       {value}
@@ -691,9 +686,20 @@ export default function UpdateProject({ query }) {
                         'project_create_edit.multiple_photos'
                       )}
                       <span
+                        role="button"
+                        tabIndex={0}
                         onClick={() =>
                           setMode(!select_photo_mode)
                         }
+                        onKeyDown={(e) => {
+                          if (
+                            e.key === 'Enter' ||
+                            e.key === ' '
+                          ) {
+                            e.preventDefault()
+                            setMode(!select_photo_mode)
+                          }
+                        }}
                         className="cursor-pointer font-semibold text-sciteensLightGreen-regular hover:text-sciteensLightGreen-dark"
                       >
                         {t(

--- a/pages/project/[id]/index.js
+++ b/pages/project/[id]/index.js
@@ -1,4 +1,4 @@
-import { doc, collection } from '@firebase/firestore'
+import { doc } from '@firebase/firestore'
 import {
   listAll,
   ref,
@@ -13,12 +13,10 @@ import {
 } from 'reactfire'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
-import Image from 'next/image'
 import Error from 'next/error'
 import Link from 'next/link'
 import File from '../../../components/File'
-import { useEffect, useState, useContext } from 'react'
-import { AppContext } from '../../../context/context'
+import { useEffect, useState } from 'react'
 import Discussion from '../../../components/Discussion'
 import ProfilePhoto from '../../../components/ProfilePhoto'
 
@@ -51,7 +49,7 @@ function Project({ query }) {
         const metadata = await getMetadata(r)
         const xhr = new XMLHttpRequest()
         xhr.responseType = 'blob'
-        xhr.onload = (e) => {
+        xhr.onload = () => {
           const blob = xhr.response
           if (xhr.status == 200) {
             blob.name = metadata.name
@@ -150,7 +148,10 @@ function Project({ query }) {
               <div className="flex -space-x-2 overflow-hidden">
                 {project.member_arr.map((member) => {
                   return (
-                    <div className="prose inline-block h-6 w-6 rounded-full ring-2 ring-white lg:h-8 lg:w-8">
+                    <div
+                      key={member.uid}
+                      className="prose inline-block h-6 w-6 rounded-full ring-2 ring-white lg:h-8 lg:w-8"
+                    >
                       <ProfilePhoto
                         uid={member.uid}
                       ></ProfilePhoto>
@@ -163,6 +164,7 @@ function Project({ query }) {
                 {project.member_arr.map((member) => {
                   return (
                     <Link
+                      key={member.uid}
                       href={`/profile/${
                         member.slug ? member.slug : ''
                       }`}
@@ -181,7 +183,7 @@ function Project({ query }) {
             {project_photo ? (
               <img
                 src={project_photo}
-                alt="Project Image"
+                alt="Project"
                 className="mt-0 w-full object-contain"
               />
             ) : loading_files ? (
@@ -195,6 +197,7 @@ function Project({ query }) {
             {project.fields.map((tag) => {
               return (
                 <Link
+                  key={tag}
                   href={{
                     pathname: '/projects',
                     query: { field: tag },

--- a/pages/project/create.js
+++ b/pages/project/create.js
@@ -40,7 +40,6 @@ import isEmail from 'validator/lib/isEmail'
 import debounce from 'lodash.debounce'
 import moment from 'moment'
 import { useDropzone } from 'react-dropzone'
-import { useTransition, animated } from '@react-spring/web'
 import {
   getTranslatedFieldsDict,
   sanitizeFileName,
@@ -213,12 +212,8 @@ export default function CreateProject() {
     }
   })
 
-  const {
-    acceptedFiles,
-    getRootProps,
-    getInputProps,
-    isDragActive,
-  } = useDropzone({ onDrop })
+  const { getRootProps, getInputProps, isDragActive } =
+    useDropzone({ onDrop })
 
   async function onChange(e, target) {
     switch (target) {
@@ -286,7 +281,7 @@ export default function CreateProject() {
         }
         break
 
-      case 'fields':
+      case 'fields': {
         const id = e.target.id
         const index = Object.keys(
           getTranslatedFieldsDict(t)
@@ -294,6 +289,7 @@ export default function CreateProject() {
         let temp = [...field_values]
         temp[index] = !temp[index]
         setFieldValues([...temp])
+      }
     }
   }
 
@@ -372,7 +368,7 @@ export default function CreateProject() {
             </p>
             <form onSubmit={(e) => createProject(e)}>
               <label
-                for="title"
+                htmlFor="title"
                 className="uppercase text-gray-600"
               >
                 {t('project_create_edit.title')}
@@ -396,7 +392,7 @@ export default function CreateProject() {
               </p>
 
               <label
-                for="start-date"
+                htmlFor="start-date"
                 className="uppercase text-gray-600"
               >
                 {t('project_create_edit.start_date')}
@@ -426,7 +422,7 @@ export default function CreateProject() {
               </p>
 
               <label
-                for="end-date"
+                htmlFor="end-date"
                 className="uppercase text-gray-600"
               >
                 {t('project_create_edit.end_date')}
@@ -456,7 +452,7 @@ export default function CreateProject() {
               </p>
 
               <label
-                for="abstract"
+                htmlFor="abstract"
                 className="uppercase text-gray-600"
               >
                 {t('project_create_edit.summary')}
@@ -480,7 +476,7 @@ export default function CreateProject() {
               </p>
 
               <label
-                for="member"
+                htmlFor="member"
                 className="uppercase text-gray-600"
               >
                 {t('project_create_edit.add_members')}
@@ -503,7 +499,7 @@ export default function CreateProject() {
                 {error_member}
               </p>
               {members.map((m, index) => (
-                <p className="p-2">
+                <p key={index} className="p-2">
                   <button
                     name={index}
                     className="mr-2 h-3 w-3 fill-current hover:text-red-900"
@@ -522,7 +518,7 @@ export default function CreateProject() {
               ))}
 
               <label
-                for="fields"
+                htmlFor="fields"
                 className="uppercase text-gray-600"
               >
                 {t('project_create_edit.fields')}
@@ -532,7 +528,7 @@ export default function CreateProject() {
                 getTranslatedFieldsDict(t)
               ).map(([key, value], index) => {
                 return (
-                  <div>
+                  <div key={key}>
                     <input
                       id={key}
                       className="form-checkbox active:outline-none mr-2 text-sciteensLightGreen-regular"
@@ -544,7 +540,7 @@ export default function CreateProject() {
                       }
                     />
                     <label
-                      for={key}
+                      htmlFor={key}
                       className="text-gray-700"
                     >
                       {value}
@@ -589,6 +585,17 @@ export default function CreateProject() {
                         'project_create_edit.multiple_photos'
                       )}{' '}
                       <span
+                        role="button"
+                        tabIndex={0}
+                        onKeyDown={(e) => {
+                          if (
+                            e.key === 'Enter' ||
+                            e.key === ' '
+                          ) {
+                            e.preventDefault()
+                            setMode(!select_photo_mode)
+                          }
+                        }}
                         onClick={() =>
                           setMode(!select_photo_mode)
                         }
@@ -632,7 +639,10 @@ export default function CreateProject() {
                         id > 0
                       )
                         return (
-                          <div className="flex w-full flex-row">
+                          <div
+                            key={f.id}
+                            className="flex w-full flex-row"
+                          >
                             <button
                               onClick={(e) =>
                                 setPhoto(e, id)

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -8,10 +8,7 @@ import { useTranslation } from 'next-i18next'
 import { useIntersectionObserver } from '../context/helpers'
 import moment from 'moment'
 
-import {
-  useFirestore,
-  useFirestoreCollectionData,
-} from 'reactfire'
+import { useFirestore } from 'reactfire'
 import firebaseConfig from '../firebaseConfig'
 import {
   getApp,
@@ -113,7 +110,11 @@ function Projects({ cached_projects }) {
         )
         const projectsQuery = firebase_query(
           projectsCollection,
-          firebase_where(documentId(), 'in', ids.slice(0, 10))
+          firebase_where(
+            documentId(),
+            'in',
+            ids.slice(0, 10)
+          )
         )
         const projectsRef = await getDocs(projectsQuery)
         projectsRef.forEach((p) => {
@@ -171,10 +172,6 @@ function Projects({ cached_projects }) {
 
   const [search, setSearch] = useState('')
   const [field, setField] = useState('All')
-
-  const imageLoader = ({ src, width, height }) => {
-    return `${src}/${width || 256}x${height || 256}`
-  }
 
   useEffect(() => {
     if (router?.isReady) {
@@ -325,110 +322,107 @@ function Projects({ cached_projects }) {
   }))
   const { t } = useTranslation('common')
 
-  const projectsComponent = projects.map(
-    (project, index) => {
-      return (
-        <Link
-          key={project.id}
-          href={`/project/${project.id}`}
+  const projectsComponent = projects.map((project) => {
+    return (
+      <Link
+        key={project.id}
+        href={`/project/${project.id}`}
+      >
+        <animated.a
+          style={project_spring}
+          className="z-50 mt-6 flex cursor-pointer items-center overflow-hidden rounded-lg bg-white p-4 shadow md:mt-8"
         >
-          <animated.a
-            style={project_spring}
-            className="z-50 mt-6 flex cursor-pointer items-center overflow-hidden rounded-lg bg-white p-4 shadow md:mt-8"
-          >
-            <div className="relative h-full max-h-[100px] max-w-[100px] overflow-hidden rounded-lg md:max-h-[200px] md:max-w-[200px]">
-              <img
-                src={
-                  project.project_photo
-                    ? project.project_photo
-                    : ''
-                }
-                className="flex-shrink-0 rounded-lg object-cover"
-              ></img>
-            </div>
-            <div className="ml-4 w-3/4 lg:w-11/12">
-              {project.member_arr && (
-                <div className="mb-1 flex flex-row items-center">
-                  <div className="flex -space-x-2 overflow-hidden">
-                    {project.member_arr.map(
-                      (member, index) => {
-                        return (
-                          <div
-                            key={index}
-                            className="inline-block h-6 w-6 rounded-full ring-2 ring-white lg:h-8 lg:w-8"
-                          >
-                            <ProfilePhoto
-                              uid={member.uid}
-                            ></ProfilePhoto>
-                          </div>
-                        )
-                      }
-                    )}
-                  </div>
-                  <p className="ml-2">
-                    By&nbsp;
-                    {project.member_arr.map((member) => {
+          <div className="relative h-full max-h-[100px] max-w-[100px] overflow-hidden rounded-lg md:max-h-[200px] md:max-w-[200px]">
+            <img
+              src={
+                project.project_photo
+                  ? project.project_photo
+                  : ''
+              }
+              alt=""
+              className="flex-shrink-0 rounded-lg object-cover"
+            ></img>
+          </div>
+          <div className="ml-4 w-3/4 lg:w-11/12">
+            {project.member_arr && (
+              <div className="mb-1 flex flex-row items-center">
+                <div className="flex -space-x-2 overflow-hidden">
+                  {project.member_arr.map(
+                    (member, index) => {
                       return (
-                        <Link
-                          href={`/profile/${
-                            member.slug ? member.slug : ''
-                          }`}
+                        <div
+                          key={index}
+                          className="inline-block h-6 w-6 rounded-full ring-2 ring-white lg:h-8 lg:w-8"
                         >
-                          <a className="font-bold text-sciteensGreen-regular no-underline hover:text-sciteensGreen-dark">
-                            {member.display + ' '}
-                          </a>
-                        </Link>
+                          <ProfilePhoto
+                            uid={member.uid}
+                          ></ProfilePhoto>
+                        </div>
                       )
-                    })}
-                  </p>
+                    }
+                  )}
                 </div>
-              )}
-              <div className="mb-2 ml-10 text-gray-500">
-                {moment(project.date).format('ll')}
-              </div>
-              <h3 className="mb-2 text-base font-semibold line-clamp-2 md:text-xl lg:text-2xl">
-                {project.title}
-              </h3>
-              <p className="mb-4 hidden line-clamp-none md:block md:line-clamp-2 lg:line-clamp-3">
-                {project.abstract}
-              </p>
-              <div className="hidden flex-row lg:flex">
-                {project.fields.map((field, index) => {
-                  if (
-                    index <
-                    checkForLongFields(project.fields)
-                  )
+                <p className="ml-2">
+                  By&nbsp;
+                  {project.member_arr.map((member) => {
                     return (
-                      <p
-                        key={index}
-                        className="z-30 mr-2 mb-2 whitespace-nowrap rounded-full bg-gray-100 py-1.5 px-3 text-xs shadow"
+                      <Link
+                        key={member.uid}
+                        href={`/profile/${
+                          member.slug ? member.slug : ''
+                        }`}
                       >
-                        {getTranslatedFieldsDict(t)[field]}
-                      </p>
+                        <a className="font-bold text-sciteensGreen-regular no-underline hover:text-sciteensGreen-dark">
+                          {member.display + ' '}
+                        </a>
+                      </Link>
                     )
-                })}
-                {project.fields.length >= 3 && (
-                  <p className="mt-1.5 hidden whitespace-nowrap text-xs text-gray-600 lg:flex">
-                    +{' '}
-                    {project.fields.length -
-                      checkForLongFields(
-                        project.fields
-                      )}{' '}
-                    more field
-                    {project.fields.length -
-                      checkForLongFields(project.fields) ==
-                    1
-                      ? ''
-                      : 's'}
-                  </p>
-                )}
+                  })}
+                </p>
               </div>
+            )}
+            <div className="mb-2 ml-10 text-gray-500">
+              {moment(project.date).format('ll')}
             </div>
-          </animated.a>
-        </Link>
-      )
-    }
-  )
+            <h3 className="mb-2 text-base font-semibold line-clamp-2 md:text-xl lg:text-2xl">
+              {project.title}
+            </h3>
+            <p className="mb-4 hidden line-clamp-none md:block md:line-clamp-2 lg:line-clamp-3">
+              {project.abstract}
+            </p>
+            <div className="hidden flex-row lg:flex">
+              {project.fields.map((field, index) => {
+                if (
+                  index < checkForLongFields(project.fields)
+                )
+                  return (
+                    <p
+                      key={index}
+                      className="z-30 mr-2 mb-2 whitespace-nowrap rounded-full bg-gray-100 py-1.5 px-3 text-xs shadow"
+                    >
+                      {getTranslatedFieldsDict(t)[field]}
+                    </p>
+                  )
+              })}
+              {project.fields.length >= 3 && (
+                <p className="mt-1.5 hidden whitespace-nowrap text-xs text-gray-600 lg:flex">
+                  +{' '}
+                  {project.fields.length -
+                    checkForLongFields(project.fields)}{' '}
+                  more field
+                  {project.fields.length -
+                    checkForLongFields(project.fields) ==
+                  1
+                    ? ''
+                    : 's'}
+                </p>
+              )}
+            </div>
+          </div>
+        </animated.a>
+      </Link>
+    )
+  })
 
   const loadingComponent = new Array(10)
     .fill(1)

--- a/pages/signin/educator.js
+++ b/pages/signin/educator.js
@@ -31,7 +31,7 @@ export default function MentorSignIn() {
   const [error_password, setErrorPassword] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [loading, setLoading] = useState(false)
+  const [, setLoading] = useState(false)
   const firestore = useFirestore()
   const auth = useAuth()
   const router = useRouter()
@@ -130,7 +130,7 @@ export default function MentorSignIn() {
           </p>
           <form onSubmit={emailSignIn}>
             <label
-              for="email"
+              htmlFor="email"
               className="uppercase text-gray-600"
             >
               {t('auth.email')}
@@ -153,7 +153,7 @@ export default function MentorSignIn() {
             </p>
 
             <label
-              for="password"
+              htmlFor="password"
               className="uppercase text-gray-600"
             >
               {t('auth.password')}

--- a/pages/signin/reset.js
+++ b/pages/signin/reset.js
@@ -63,7 +63,7 @@ export default function Reset() {
               {t('auth.why_reset_password')}
             </p>
             <label
-              for="email"
+              htmlFor="email"
               className="uppercase text-gray-600"
             >
               {t('auth.email')}

--- a/pages/signin/student.js
+++ b/pages/signin/student.js
@@ -35,7 +35,7 @@ export default function StudentSignIn() {
   const [error_password, setErrorPassword] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [loading, setLoading] = useState(false)
+  const [, setLoading] = useState(false)
   const firestore = useFirestore()
   const auth = useAuth()
   const router = useRouter()
@@ -134,7 +134,7 @@ export default function StudentSignIn() {
           </p>
           <form onSubmit={emailSignIn}>
             <label
-              for="email"
+              htmlFor="email"
               className="uppercase text-gray-600"
             >
               {t('auth.email')}
@@ -157,7 +157,7 @@ export default function StudentSignIn() {
             </p>
 
             <label
-              for="password"
+              htmlFor="password"
               className="uppercase text-gray-600"
             >
               {t('auth.password')}

--- a/pages/signup/educator.js
+++ b/pages/signup/educator.js
@@ -8,8 +8,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
 
 import { useFirestore, useAuth } from 'reactfire'
-import { doc, setDoc, updateDoc } from '@firebase/firestore'
-import { updateProfile } from '@firebase/auth'
+import { doc, setDoc } from '@firebase/firestore'
 import {
   createUserWithEmailAndPassword,
   RecaptchaVerifier,
@@ -45,7 +44,6 @@ export default function MentorSignUp() {
   const [password, setPassword] = useState('')
   const [institution, setInstitution] = useState('')
   const [position, setPosition] = useState('')
-  const [ethnicity, setEthnicity] = useState('Cuban')
   const [race, setRace] = useState(
     'American Indian or Alaska Native'
   )
@@ -60,7 +58,7 @@ export default function MentorSignUp() {
   const [error_password, setErrorPassword] = useState('')
   const [error_institution, setErrorInstitution] =
     useState('')
-  const [error_terms, setErrorTerms] = useState('')
+  const [error_terms] = useState('')
 
   const firestore = useFirestore()
   const auth = useAuth()
@@ -78,7 +76,7 @@ export default function MentorSignUp() {
         'recaptcha-container',
         {
           size: 'normal',
-          callback: (response) => {
+          callback: () => {
             setRecaptchaSolved(true)
           },
           'expired-callback': () => {
@@ -87,39 +85,13 @@ export default function MentorSignUp() {
         },
         auth
       )
-      const recaptchaId = await recaptchaVerifier.render()
+      await recaptchaVerifier.render()
       const verified = await recaptchaVerifier.verify()
       if (verified.length) {
         setRecaptchaSolved(true)
       }
     }
   })
-
-  async function finishSignUp() {
-    if (!terms) {
-      setErrorTerms(t('auth.error_terms'))
-    } else {
-      try {
-        setLoading(true)
-        await updateDoc(
-          doc(firestore, 'profiles', user.uid),
-          {
-            display: first_name + ' ' + last_name,
-            birthday: moment(birthday).toISOString(),
-            race: race,
-            ethnicity: ethnicity,
-          }
-        )
-        await updateProfile(user, {
-          displayName: first_name + ' ' + last_name,
-        })
-        router.push('/dashboard')
-      } catch {
-        setLoading(false)
-        setErrorName(t('auth.unable_to_create'))
-      }
-    }
-  }
 
   async function onChange(e, target) {
     switch (target) {
@@ -269,7 +241,7 @@ export default function MentorSignUp() {
             {t('auth.educate_on_sciteens')}
           </h1>
           <b className="text-red-700">
-            We currently aren't accepting new educator
+            We currently aren&apos;t accepting new educator
             signups.
           </b>
           <p className="mb-6 text-center text-gray-700">
@@ -567,12 +539,11 @@ export default function MentorSignUp() {
                   </div>
                 </label>
               </div>
-              <p
-                v-if="e_terms"
-                className="mb-6 text-sm text-red-800"
-              >
-                {error_terms}
-              </p>
+              {error_terms && (
+                <p className="mb-6 text-sm text-red-800">
+                  {error_terms}
+                </p>
+              )}
             </div>
             <button
               type="submit"

--- a/pages/signup/finish.js
+++ b/pages/signup/finish.js
@@ -191,7 +191,7 @@ export default function FinishSignUp() {
             <div className="flex flex-row">
               <div className="mr-1">
                 <label
-                  for="first-name"
+                  htmlFor="first-name"
                   className="uppercase text-gray-600"
                 >
                   {t('auth.first_name')}
@@ -217,7 +217,7 @@ export default function FinishSignUp() {
 
               <div className="ml-2">
                 <label
-                  for="last-name"
+                  htmlFor="last-name"
                   className="mt-4 uppercase text-gray-600"
                 >
                   {t('auth.last_name')}
@@ -243,7 +243,7 @@ export default function FinishSignUp() {
             </div>
 
             <label
-              for="birthday"
+              htmlFor="birthday"
               className="uppercase text-gray-600"
             >
               {t('auth.birthday')}
@@ -274,7 +274,7 @@ export default function FinishSignUp() {
             </p>
 
             <label
-              for="gender"
+              htmlFor="gender"
               className="uppercase text-gray-600"
             >
               {t('auth.gender')}
@@ -301,7 +301,7 @@ export default function FinishSignUp() {
             </select>
 
             <label
-              for="race"
+              htmlFor="race"
               className="uppercase text-gray-600"
             >
               {t('auth.race')}
@@ -354,7 +354,7 @@ export default function FinishSignUp() {
                     className="form-checkbox active:outline-none my-auto mr-2 leading-tight text-sciteensLightGreen-regular"
                   />
                   <label
-                    for="terms"
+                    htmlFor="terms"
                     className="whitespace-nowrap text-sm text-gray-600"
                   >
                     <div className="flex flex-row">
@@ -367,12 +367,11 @@ export default function FinishSignUp() {
                     </div>
                   </label>
                 </div>
-                <p
-                  v-if="e_terms"
-                  className="mb-6 text-sm text-red-800"
-                >
-                  {error_terms}
-                </p>
+                {error_terms && (
+                  <p className="mb-6 text-sm text-red-800">
+                    {error_terms}
+                  </p>
+                )}
               </div>
               <button
                 type="submit"

--- a/pages/signup/index.js
+++ b/pages/signup/index.js
@@ -7,8 +7,6 @@ import { useTranslation } from 'next-i18next'
 
 export default function SignUpIndex() {
   const { t } = useTranslation('common')
-  const [show_mentor_info, setShowMentorInfo] =
-    useState(false)
   const [show_student_info, setShowStudentInfo] =
     useState(false)
 
@@ -73,9 +71,8 @@ export default function SignUpIndex() {
               <a className="m-6 h-56 w-56 rounded bg-white shadow hover:shadow-md">
                 {show_student_info ? (
                   <div className="relative pt-8">
-                    <img
-                      src="/assets/zondicons/close-solid.svg"
-                      alt="Close"
+                    <button
+                      type="button"
                       className="absolute top-0 right-0 m-2 h-6 w-6"
                       onClick={(e) => {
                         e.preventDefault()
@@ -83,16 +80,21 @@ export default function SignUpIndex() {
                           !show_student_info
                         )
                       }}
-                    />
+                    >
+                      <img
+                        src="/assets/zondicons/close-solid.svg"
+                        alt="Close"
+                        className="h-6 w-6"
+                      />
+                    </button>
                     <h2 className="mx-2 text-xl text-sciteensGreen-regular">
                       {t('auth.student_info')}
                     </h2>
                   </div>
                 ) : (
                   <div className="relative">
-                    <img
-                      src="/assets/zondicons/question.svg"
-                      alt="Question"
+                    <button
+                      type="button"
                       className="absolute top-0 right-0 m-2 h-6 w-6"
                       onClick={(e) => {
                         e.preventDefault()
@@ -100,7 +102,13 @@ export default function SignUpIndex() {
                           !show_student_info
                         )
                       }}
-                    />
+                    >
+                      <img
+                        src="/assets/zondicons/question.svg"
+                        alt="Question"
+                        className="h-6 w-6"
+                      />
+                    </button>
                     <img
                       src="/assets/student.svg"
                       alt="Student Icon"

--- a/pages/signup/student.js
+++ b/pages/signup/student.js
@@ -8,7 +8,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
 
 import { useFirestore, useAuth } from 'reactfire'
-import { doc, getDoc, setDoc } from '@firebase/firestore'
+import { doc, setDoc } from '@firebase/firestore'
 import {
   updateProfile,
   createUserWithEmailAndPassword,
@@ -58,7 +58,7 @@ export default function StudentSignUp() {
   const [error_email, setErrorEmail] = useState('')
   const [error_password, setErrorPassword] = useState('')
   const [error_birthday, setErrorBirthday] = useState('')
-  const [error_terms, setErrorTerms] = useState('')
+  const [error_terms] = useState('')
 
   const firestore = useFirestore()
   const auth = useAuth()
@@ -76,7 +76,7 @@ export default function StudentSignUp() {
         'recaptcha-container',
         {
           size: 'normal',
-          callback: (response) => {
+          callback: () => {
             setRecaptchaSolved(true)
           },
           'expired-callback': () => {
@@ -85,7 +85,7 @@ export default function StudentSignUp() {
         },
         auth
       )
-      const recaptchaId = await recaptchaVerifier.render()
+      await recaptchaVerifier.render()
       const verified = await recaptchaVerifier.verify()
       if (verified.length) {
         setRecaptchaSolved(true)
@@ -257,7 +257,7 @@ export default function StudentSignUp() {
             <div className="flex flex-row">
               <div className="mr-1">
                 <label
-                  for="first-name"
+                  htmlFor="first-name"
                   className="uppercase text-gray-600"
                 >
                   {t('auth.first_name')}
@@ -283,7 +283,7 @@ export default function StudentSignUp() {
 
               <div className="ml-1">
                 <label
-                  for="last-name"
+                  htmlFor="last-name"
                   className="mt-4 uppercase text-gray-600"
                 >
                   {t('auth.last_name')}
@@ -309,7 +309,7 @@ export default function StudentSignUp() {
             </div>
 
             <label
-              for="email"
+              htmlFor="email"
               className="uppercase text-gray-600"
             >
               {t('auth.email')}
@@ -332,7 +332,7 @@ export default function StudentSignUp() {
             </p>
 
             <label
-              for="password"
+              htmlFor="password"
               className="uppercase text-gray-600"
             >
               {t('auth.password')}
@@ -355,7 +355,7 @@ export default function StudentSignUp() {
             </p>
 
             <label
-              for="birthday"
+              htmlFor="birthday"
               className="uppercase text-gray-600"
             >
               {t('auth.birthday')}
@@ -386,7 +386,7 @@ export default function StudentSignUp() {
             </p>
 
             <label
-              for="gender"
+              htmlFor="gender"
               className="uppercase text-gray-600"
             >
               {t('auth.gender')}
@@ -424,7 +424,7 @@ export default function StudentSignUp() {
             </div>
 
             <label
-              for="race"
+              htmlFor="race"
               className="uppercase text-gray-600"
             >
               {t('auth.race')}
@@ -490,7 +490,7 @@ export default function StudentSignUp() {
                   className="form-checkbox active:outline-none my-auto mr-2 leading-tight text-sciteensLightGreen-regular"
                 />
                 <label
-                  for="terms"
+                  htmlFor="terms"
                   className="whitespace-nowrap text-sm text-gray-600"
                 >
                   <div className="flex flex-row">
@@ -503,12 +503,11 @@ export default function StudentSignUp() {
                   </div>
                 </label>
               </div>
-              <p
-                v-if="e_terms"
-                className="mb-6 text-sm text-red-800"
-              >
-                {error_terms}
-              </p>
+              {error_terms && (
+                <p className="mb-6 text-sm text-red-800">
+                  {error_terms}
+                </p>
+              )}
             </div>
             <button
               type="submit"


### PR DESCRIPTION
Clear all 566 ESLint errors that were failing `next build` (eslint.ignoreDuringBuilds: false) across 32 files:

- Remove unused imports/vars/params; drop unused useState slots
- Escape " and ' in JSX text (react/no-unescaped-entities)
- Add missing key props in iterators (react/jsx-key)
- Add a11y support to click handlers: role/tabIndex/onKeyDown on static elements, wrap non-interactive click targets in <button>, add alt text (jsx-a11y)
- for -> htmlFor; convert leftover Vue-isms (v-if/v-else/resize) to React conditional rendering (react/no-unknown-property)
- Wrap case-block declarations (no-case-declarations)
- Remove dead/unreachable code (article handleSwipe, educator finishSignUp, profile removeMember button)
- Add rel="noreferrer" to target="_blank" links
- Add missing getDocs import (project edit)
- Add local classnames helper in Pagination (package not installed)

Behavior preserved; verified 0 ESLint errors project-wide.