### PR TITLE
fix: article page mobile visual bugs

### DIFF
--- a/components/ui/carousel.jsx
+++ b/components/ui/carousel.jsx
@@ -1,0 +1,228 @@
+import * as React from 'react'
+import useEmblaCarousel from 'embla-carousel-react'
+
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from 'lucide-react'
+
+const CarouselContext = React.createContext(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+
+  if (!context) {
+    throw new Error(
+      'useCarousel must be used within a <Carousel />'
+    )
+  }
+
+  return context
+}
+
+function Carousel({
+  orientation = 'horizontal',
+  opts,
+  setApi,
+  plugins,
+  className,
+  children,
+  ...props
+}) {
+  const [carouselRef, api] = useEmblaCarousel(
+    {
+      ...opts,
+      axis: orientation === 'horizontal' ? 'x' : 'y',
+    },
+    plugins
+  )
+  const [canScrollPrev, setCanScrollPrev] =
+    React.useState(false)
+  const [canScrollNext, setCanScrollNext] =
+    React.useState(false)
+
+  const onSelect = React.useCallback((api) => {
+    if (!api) return
+    setCanScrollPrev(api.canScrollPrev())
+    setCanScrollNext(api.canScrollNext())
+  }, [])
+
+  const scrollPrev = React.useCallback(() => {
+    api?.scrollPrev()
+  }, [api])
+
+  const scrollNext = React.useCallback(() => {
+    api?.scrollNext()
+  }, [api])
+
+  const handleKeyDown = React.useCallback(
+    (event) => {
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault()
+        scrollPrev()
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault()
+        scrollNext()
+      }
+    },
+    [scrollPrev, scrollNext]
+  )
+
+  React.useEffect(() => {
+    if (!api || !setApi) return
+    setApi(api)
+  }, [api, setApi])
+
+  React.useEffect(() => {
+    if (!api) return
+    onSelect(api)
+    api.on('reInit', onSelect)
+    api.on('select', onSelect)
+
+    return () => {
+      api?.off('select', onSelect)
+    }
+  }, [api, onSelect])
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        carouselRef,
+        api: api,
+        opts,
+        orientation:
+          orientation ||
+          (opts?.axis === 'y' ? 'vertical' : 'horizontal'),
+        scrollPrev,
+        scrollNext,
+        canScrollPrev,
+        canScrollNext,
+      }}
+    >
+      <div
+        onKeyDownCapture={handleKeyDown}
+        className={cn('relative', className)}
+        role="region"
+        aria-roledescription="carousel"
+        data-slot="carousel"
+        {...props}
+      >
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  )
+}
+
+function CarouselContent({ className, ...props }) {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    <div
+      ref={carouselRef}
+      className="overflow-hidden"
+      data-slot="carousel-content"
+    >
+      <div
+        className={cn(
+          'flex',
+          orientation === 'horizontal'
+            ? '-ml-4'
+            : '-mt-4 flex-col',
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CarouselItem({ className, ...props }) {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      role="group"
+      aria-roledescription="slide"
+      data-slot="carousel-item"
+      className={cn(
+        'min-w-0 shrink-0 grow-0 basis-full',
+        orientation === 'horizontal' ? 'pl-4' : 'pt-4',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CarouselPrevious({
+  className,
+  variant = 'outline',
+  size = 'icon-sm',
+  ...props
+}) {
+  const { orientation, scrollPrev, canScrollPrev } =
+    useCarousel()
+
+  return (
+    <Button
+      data-slot="carousel-previous"
+      variant={variant}
+      size={size}
+      className={cn(
+        'absolute touch-manipulation rounded-full',
+        orientation === 'horizontal'
+          ? 'inset-y-0 -left-12 my-auto'
+          : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  )
+}
+
+function CarouselNext({
+  className,
+  variant = 'outline',
+  size = 'icon-sm',
+  ...props
+}) {
+  const { orientation, scrollNext, canScrollNext } =
+    useCarousel()
+
+  return (
+    <Button
+      data-slot="carousel-next"
+      variant={variant}
+      size={size}
+      className={cn(
+        'absolute touch-manipulation rounded-full',
+        orientation === 'horizontal'
+          ? 'inset-y-0 -right-12 my-auto'
+          : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ChevronRightIcon />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  )
+}
+
+export {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+  useCarousel,
+}

--- a/lib/prismicImageLoader.js
+++ b/lib/prismicImageLoader.js
@@ -9,18 +9,25 @@ function appendImgixParams(src, params) {
 }
 
 // `next/image` loaders only ever receive `{ src, width,
-// quality }` — never `height` — so the target height is fixed
-// per call site rather than threaded through the loader.
+// quality }` — never `height` — so a fixed `height` would drift
+// out of aspect ratio whenever `next/image` requests a
+// different `width` (a smaller device size on mobile, or a 2x
+// DPR srcset entry). Deriving the crop height from the
+// `fallbackWidth:height` ratio instead keeps every requested
+// width cropped to the same aspect ratio the call site intended.
 export function createCropImageLoader(
   fallbackWidth,
   height
 ) {
+  const aspectRatio = fallbackWidth / height
   return function cropImageLoader({ src, width }) {
+    const targetWidth = width || fallbackWidth
+    const targetHeight = Math.round(
+      targetWidth / aspectRatio
+    )
     return appendImgixParams(
       src,
-      `fit=crop&crop=faces&w=${
-        width || fallbackWidth
-      }&h=${height}`
+      `fit=crop&crop=faces&w=${targetWidth}&h=${targetHeight}`
     )
   }
 }

--- a/lib/prismicImageLoader.test.js
+++ b/lib/prismicImageLoader.test.js
@@ -31,7 +31,7 @@ describe('maxWidthImageLoader', () => {
 })
 
 describe('createCropImageLoader', () => {
-  it('uses the requested width and fixed height, appending with "?"', () => {
+  it('scales height proportionally to the requested width, appending with "?"', () => {
     const loader = createCropImageLoader(300, 200)
     expect(
       loader({
@@ -39,11 +39,11 @@ describe('createCropImageLoader', () => {
         width: 600,
       })
     ).toBe(
-      'https://images.prismic.io/img.jpg?fit=crop&crop=faces&w=600&h=200'
+      'https://images.prismic.io/img.jpg?fit=crop&crop=faces&w=600&h=400'
     )
   })
 
-  it('falls back to fallbackWidth when width is not provided', () => {
+  it('falls back to fallbackWidth/height when width is not provided', () => {
     const loader = createCropImageLoader(300, 200)
     expect(
       loader({ src: 'https://images.prismic.io/img.jpg' })
@@ -60,7 +60,7 @@ describe('createCropImageLoader', () => {
         width: 600,
       })
     ).toBe(
-      'https://images.prismic.io/img.jpg?auto=compress&fit=crop&crop=faces&w=600&h=200'
+      'https://images.prismic.io/img.jpg?auto=compress&fit=crop&crop=faces&w=600&h=400'
     )
   })
 
@@ -70,5 +70,24 @@ describe('createCropImageLoader', () => {
     const src = 'https://images.prismic.io/img.jpg'
     expect(avatarLoader({ src })).toContain('w=100&h=100')
     expect(bannerLoader({ src })).toContain('w=1200&h=300')
+  })
+
+  // Regression test for the profile-picture-inflation bug: reusing
+  // one loader instance across differently-sized `next/image`
+  // requests (mobile srcset widths, 2x DPR, or a smaller display
+  // size than the loader was tuned for) must never distort the
+  // intended aspect ratio, only change resolution.
+  it('keeps a square avatar crop square at every requested width', () => {
+    const avatarLoader = createCropImageLoader(256, 256)
+    const src = 'https://images.prismic.io/img.jpg'
+    expect(avatarLoader({ src, width: 48 })).toContain(
+      'w=48&h=48'
+    )
+    expect(avatarLoader({ src, width: 96 })).toContain(
+      'w=96&h=96'
+    )
+    expect(avatarLoader({ src, width: 512 })).toContain(
+      'w=512&h=512'
+    )
   })
 })

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "compression-webpack-plugin": "^10.0.0",
+    "embla-carousel-react": "^8.6.0",
     "firebase": "^12.16.0",
     "image-minimizer-webpack-plugin": "^3.8.3",
     "lodash.debounce": "^4.0.8",

--- a/pages/article/[slug].js
+++ b/pages/article/[slug].js
@@ -1,5 +1,5 @@
 import { RichText } from 'prismic-reactjs'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 var Prismic = require('@prismicio/client')
 import Link from 'next/link'
 import moment from 'moment'
@@ -12,11 +12,17 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
 import { logEvent, getAnalytics } from 'firebase/analytics'
 import { createCropImageLoader } from '../../lib/prismicImageLoader'
+import { getTranslatedFieldsDict } from '../../context/helpers'
+import { Button } from '@/components/ui/button'
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '@/components/ui/carousel'
 
 function Article({ article, recommendations }) {
-  const [, setLeftVisible] = useState(false)
-  const [, setRightVisible] = useState(true)
-  const [scrollIndex, setScrollIndex] = useState(-1)
   const [vote, setVote] = useState(null)
   const isAmp = false
   const { t } = useTranslation('common')
@@ -44,7 +50,17 @@ function Article({ article, recommendations }) {
     }
   }
 
-  const imageLoader = createCropImageLoader(582, 389)
+  // Each usage below gets its own loader tuned to its own display
+  // aspect ratio (cover, square avatars, 16:9 recommendation
+  // thumbnails) — sharing one loader across mismatched shapes is
+  // what previously stretched avatars and thumbnails out of shape.
+  const coverImageLoader = createCropImageLoader(670, 400)
+  const avatarImageLoader = createCropImageLoader(256, 256)
+  const recommendationImageLoader = createCropImageLoader(
+    1280,
+    720
+  )
+  const translatedFields = getTranslatedFieldsDict(t)
 
   function readingTime(article) {
     let article_length = 0
@@ -61,78 +77,26 @@ function Article({ article, recommendations }) {
     return `${time_to_read} minute read`
   }
 
-  useEffect(() => {
-    if (scrollIndex < 3) {
-      setRightVisible(true)
-    } else if (scrollIndex == 3) {
-      setRightVisible(false)
-    }
-    if (scrollIndex >= 0) {
-      setLeftVisible(true)
-    } else if (scrollIndex == -1) {
-      setLeftVisible(false)
-    }
-  }, [scrollIndex])
-
-  function scroll(e, direction, index) {
-    e.preventDefault()
-    let element = document.getElementById('readMore')
-
-    if (index >= 0) {
-      if (index == 0) {
-        element.scrollTo(0, 0)
-        setScrollIndex(-1)
-      } else {
-        element.scrollTo(
-          document.getElementById(
-            'i-' +
-              (window.innerWidth >= 768 ? index - 1 : index)
-          )?.offsetLeft,
-          0
-        )
-        setScrollIndex(index - 1)
-      }
-      return
-    }
-
-    if (direction == 'right') {
-      if (scrollIndex < 4) {
-        element.scrollTo(
-          document.getElementById('i-' + (scrollIndex + 1))
-            ?.offsetLeft,
-          0
-        )
-        setScrollIndex(scrollIndex + 1)
-      }
-    } else {
-      if (scrollIndex > 0) {
-        element.scrollTo(
-          document.getElementById('i-' + (scrollIndex - 1))
-            ?.offsetLeft,
-          0
-        )
-      } else if (scrollIndex == 0) {
-        element.scrollTo(0, 0)
-      }
-      setScrollIndex(scrollIndex - 1)
-    }
-  }
-
   const about_the_author = article.data.body.map(
     (slice, index) => {
       if (slice.slice_type == 'about_the_author') {
         return (
           <div key={index} className="inline-block">
             <h3>{t('article.about_the_author')}</h3>
-            <div className="flex flex-col items-center lg:flex-row">
-              <Image
-                className="h-20 w-20 grow-0 rounded-full"
-                height="256"
-                width="256"
-                loader={imageLoader}
-                src={slice.primary.headshot.url}
-              />
-              <p className="ml-4">
+            <div className="flex flex-col items-center gap-4 lg:flex-row">
+              <div className="not-prose relative h-20 w-20 shrink-0 overflow-hidden rounded-full">
+                <Image
+                  fill
+                  sizes="80px"
+                  className="object-cover"
+                  loader={avatarImageLoader}
+                  src={slice.primary.headshot.url}
+                  alt={RichText.asText(
+                    slice.primary.information
+                  )}
+                />
+              </div>
+              <p className="text-center lg:text-left">
                 {RichText.asText(slice.primary.information)}
               </p>
             </div>
@@ -152,16 +116,21 @@ function Article({ article, recommendations }) {
           {slice.items.map((interview, ix) => {
             return (
               <div key={ix} className="inline-block">
-                <div className="flex flex-col items-center lg:flex-row">
-                  <Image
-                    className="h-20 w-20 rounded-full"
-                    height="64"
-                    width="64"
-                    loader={imageLoader}
-                    src={interview.headshot.url}
-                  />
+                <div className="flex flex-col items-center gap-4 lg:flex-row">
+                  <div className="not-prose relative h-20 w-20 shrink-0 overflow-hidden rounded-full">
+                    <Image
+                      fill
+                      sizes="80px"
+                      className="object-cover"
+                      loader={avatarImageLoader}
+                      src={interview.headshot.url}
+                      alt={RichText.asText(
+                        interview.information
+                      )}
+                    />
+                  </div>
                   <h4
-                    className="ml-4"
+                    className="text-center lg:text-left"
                     style={{
                       marginTop: 0,
                       marginBottom: 0,
@@ -184,14 +153,19 @@ function Article({ article, recommendations }) {
   const author_image = article.data.body.map((slice) => {
     if (slice.slice_type == 'about_the_author') {
       return (
-        <Image
+        <div
           key={slice.primary.headshot.url}
-          className="rounded-full"
-          height="48"
-          width="48"
-          loader={imageLoader}
-          src={slice.primary.headshot.url}
-        />
+          className="not-prose relative h-12 w-12 shrink-0 overflow-hidden rounded-full"
+        >
+          <Image
+            fill
+            sizes="48px"
+            className="object-cover"
+            loader={avatarImageLoader}
+            src={slice.primary.headshot.url}
+            alt={article.data.author}
+          />
+        </div>
       )
     } else {
       return null
@@ -201,38 +175,42 @@ function Article({ article, recommendations }) {
   const recommendationsRendered = recommendations.map(
     (a, index) => {
       return (
-        <Link
+        <CarouselItem
           key={index}
-          href={`/article/${a.uid}`}
-          id={'i-' + index}
-          className="mr-[5vw] mt-6 w-[75vw] shrink-0 cursor-pointer rounded-lg bg-white p-4 shadow-sm hover:shadow-md  md:mr-[2.9vw] md:mt-8 md:w-[31vw]"
+          className="basis-3/4 md:basis-1/3"
         >
-          <div className="relative">
-            <Image
-              className="shrink-0 rounded-lg object-cover"
-              loader={imageLoader}
-              src={a.data.image.url}
-              width={1280}
-              height={720}
-            />
-          </div>
-          <div className="">
-            <h3 className="line-clamp-1 text-lg font-semibold">
-              {RichText.asText(a.data.title)}
-            </h3>
-            <p className="line-clamp-3 mb-auto text-sm">
-              {a.data.description}
-            </p>
-            <p className="line-clamp-1 mt-2 hidden text-sm lg:flex">
-              By{' '}
-              {a.data.author +
-                ' · ' +
-                moment(a.data.date).format('ll') +
-                ' · ' +
-                readingTime(a.data.text)}
-            </p>
-          </div>
-        </Link>
+          <Link
+            href={`/article/${a.uid}`}
+            className="block cursor-pointer rounded-lg bg-white p-4 shadow-sm hover:shadow-md"
+          >
+            <div className="relative aspect-video w-full overflow-hidden rounded-lg">
+              <Image
+                fill
+                sizes="(min-width: 768px) 31vw, 75vw"
+                className="object-cover"
+                loader={recommendationImageLoader}
+                src={a.data.image.url}
+                alt={RichText.asText(a.data.title)}
+              />
+            </div>
+            <div>
+              <h3 className="line-clamp-1 text-lg font-semibold">
+                {RichText.asText(a.data.title)}
+              </h3>
+              <p className="line-clamp-3 mb-auto text-sm">
+                {a.data.description}
+              </p>
+              <p className="line-clamp-1 mt-2 hidden text-sm lg:flex">
+                By{' '}
+                {a.data.author +
+                  ' · ' +
+                  moment(a.data.date).format('ll') +
+                  ' · ' +
+                  readingTime(a.data.text)}
+              </p>
+            </div>
+          </Link>
+        </CarouselItem>
       )
     }
   )
@@ -274,7 +252,7 @@ function Article({ article, recommendations }) {
             />
           </Head>
           <main>
-            <article className="prose prose-sm wrap-break-word lg:prose-lg mx-auto mt-8 overflow-hidden px-4">
+            <article className="prose wrap-break-word lg:prose-lg mx-auto mt-8 overflow-hidden px-4">
               <h1>{RichText.asText(article.data.title)}</h1>
               <div>
                 <div className="mb-4 flex items-center">
@@ -282,7 +260,7 @@ function Article({ article, recommendations }) {
                   <p className="ml-6 text-lg text-black ">
                     {t('article.by')} {article.data.author}{' '}
                     <br />
-                    <span className="text-gray-500">
+                    <span className="text-gray-700">
                       {' '}
                       {moment(article.data.date).format(
                         'MMMM DD, YYYY'
@@ -291,32 +269,38 @@ function Article({ article, recommendations }) {
                     </span>
                   </p>
                 </div>
-                <div className="flex flex-row flex-wrap">
+                <div className="not-prose flex flex-row flex-wrap">
                   {article.tags.map((tag) => {
                     return (
-                      <Link
+                      <Button
                         key={tag}
-                        href={{
-                          pathname: '/articles',
-                          query: { field: tag },
-                        }}
-                      >
-                        <p className="my-1 mr-4 cursor-pointer rounded-full bg-white px-5 py-1.5 text-base shadow-sm hover:shadow-md">
-                          {tag}
-                        </p>
-                      </Link>
+                        variant="secondary"
+                        className="bg-card hover:bg-muted mb-1 mr-4 rounded-full border border-gray-300 shadow-sm"
+                        render={
+                          <Link
+                            href={{
+                              pathname: '/articles',
+                              query: { field: tag },
+                            }}
+                          >
+                            {translatedFields[tag] || tag}
+                          </Link>
+                        }
+                      />
                     )
                   })}
                 </div>
               </div>
               <div>
-                {/* Image Slider */}
+                {/* Cover image */}
                 <Image
-                  loader={imageLoader}
+                  loader={coverImageLoader}
                   src={article.data.image.url}
-                  width="670"
-                  height="400"
-                  className="mt-0 object-cover"
+                  alt={RichText.asText(article.data.title)}
+                  width={670}
+                  height={400}
+                  sizes="(min-width: 1024px) 670px, 100vw"
+                  className="mt-0 h-auto w-full rounded-lg object-cover"
                 />
 
                 <div>
@@ -382,55 +366,14 @@ function Article({ article, recommendations }) {
             <h3 className="mt-8 text-center text-2xl font-semibold md:text-5xl">
               {t('article.related')}
             </h3>
-            <div className="relative">
-              <div
-                id="readMore"
-                style={{ scrollBehavior: 'smooth' }}
-                className="flex flex-row overflow-x-hidden px-[12.5vw] pb-8 transition-all md:px-[16.5vw]"
-              >
-                {recommendationsRendered}
-                <button
-                  onClick={(e) => scroll(e, 'right')}
-                  className={`absolute right-6 top-1/2 z-50 h-12 w-12 -translate-y-1/2 transform rounded-full bg-white opacity-70 shadow hover:opacity-100 hover:shadow-lg lg:h-16 lg:w-16
-                                  `}
-                >
-                  <svg
-                    className="m-auto h-2/3"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 20 20"
-                  >
-                    <path d="M12.95 10.707l.707-.707L8 4.343 6.586 5.757 10.828 10l-4.242 4.243L8 15.657l4.95-4.95z" />
-                  </svg>
-                </button>
-                <button
-                  onClick={(e) => scroll(e, 'left')}
-                  className={`absolute left-6 top-1/2 z-50 h-12 w-12 -translate-y-1/2 transform rounded-full bg-white opacity-70 shadow hover:opacity-100 hover:shadow-lg lg:h-16 lg:w-16
-                                  `}
-                >
-                  <svg
-                    className="m-auto h-2/3"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 20 20"
-                  >
-                    <path d="M7.05 9.293L6.343 10 12 15.657l1.414-1.414L9.172 10l4.242-4.243L12 4.343z" />
-                  </svg>
-                </button>
-              </div>
-            </div>
-            <div className="mx-auto mb-20 flex flex-row justify-center">
-              {new Array(5).fill(1).map((data, i) => {
-                return (
-                  <button
-                    key={i}
-                    onClick={(e) => scroll(e, null, i)}
-                    className={`h-[10px] w-[10px] rounded-full border border-black ${
-                      scrollIndex == i - 1
-                        ? 'bg-black'
-                        : 'bg-transparent'
-                    } ${i == 4 ? '' : 'mr-4'}`}
-                  />
-                )
-              })}
+            <div className="mx-auto w-11/12 max-w-4xl pb-8">
+              <Carousel opts={{ align: 'start' }}>
+                <CarouselContent>
+                  {recommendationsRendered}
+                </CarouselContent>
+                <CarouselPrevious className="left-2 lg:-left-12" />
+                <CarouselNext className="right-2 lg:-right-12" />
+              </Carousel>
             </div>
           </main>
         </>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       compression-webpack-plugin:
         specifier: ^10.0.0
         version: 10.0.0(webpack@5.108.3)
+      embla-carousel-react:
+        specifier: ^8.6.0
+        version: 8.6.0(react@18.3.1)
       firebase:
         specifier: ^12.16.0
         version: 12.16.0
@@ -5319,6 +5322,28 @@ packages:
 
   /electron-to-chromium@1.5.384:
     resolution: {integrity: sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==}
+
+  /embla-carousel-react@8.6.0(react@18.3.1):
+    resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    dependencies:
+      embla-carousel: 8.6.0
+      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
+      react: 18.3.1
+    dev: false
+
+  /embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
+    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+    dependencies:
+      embla-carousel: 8.6.0
+    dev: false
+
+  /embla-carousel@8.6.0:
+    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
+    dev: false
 
   /emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}

--- a/tests/pages/article/slug.test.js
+++ b/tests/pages/article/slug.test.js
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  cleanup,
+  render,
+  screen,
+} from '@testing-library/react'
+import Article from '@/pages/article/[slug]'
+
+// Lives under tests/pages/ rather than pages/article/ — see the comment in
+// tests/pages/signup/student.test.js for why (Next's Pages Router treats
+// every `.js` under `pages/` as a route).
+//
+// Regression coverage for three of the reported visual bugs, all rooted in
+// the article detail page markup rather than the shared prismicImageLoader
+// fix (covered directly in lib/prismicImageLoader.test.js):
+// - tag "buttons" rendering as a bare `<p>` link (no `<button>` semantics,
+//   underlined by the surrounding `.prose` typography styles) instead of
+//   the same field-filter Button used on /articles.
+// - avatar images missing a fixed-size, `object-cover` box, which is what
+//   let a mismatched loader aspect ratio stretch them.
+// - the "More on this topic" recommendations rendering as plain links
+//   instead of the shadcn Carousel's swipeable items.
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ query: { slug: 'test-article' } }),
+}))
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}))
+
+vi.mock('firebase/analytics', () => ({
+  getAnalytics: vi.fn(),
+  logEvent: vi.fn(),
+}))
+
+// Fetches Firestore comments through onSnapshot; irrelevant to the
+// article body markup under test here.
+vi.mock('@/components/Discussion', () => ({
+  default: () => null,
+}))
+
+afterEach(cleanup)
+
+function buildArticle() {
+  return {
+    uid: 'test-article',
+    tags: ['Biology', 'Made Up Tag'],
+    data: {
+      title: [{ type: 'heading1', text: 'Test Article' }],
+      description: 'A test article',
+      author: 'Test Author',
+      date: '2024-01-01',
+      image: {
+        url: 'https://images.prismic.io/test/cover.jpg',
+      },
+      text: [
+        {
+          type: 'paragraph',
+          text: 'Body text',
+          spans: [],
+        },
+      ],
+      body: [
+        {
+          slice_type: 'about_the_author',
+          primary: {
+            headshot: {
+              url: 'https://images.prismic.io/test/headshot.jpg',
+            },
+            information: [
+              { type: 'paragraph', text: 'Author bio' },
+            ],
+          },
+        },
+      ],
+    },
+  }
+}
+
+function buildRecommendations(count) {
+  return Array.from({ length: count }, (_, i) => ({
+    uid: `rec-${i}`,
+    data: {
+      title: [
+        { type: 'heading1', text: `Recommendation ${i}` },
+      ],
+      description: 'A recommendation',
+      author: 'Rec Author',
+      date: '2024-01-01',
+      image: {
+        url: 'https://images.prismic.io/test/rec.jpg',
+      },
+      image_slider: [],
+      text: [],
+    },
+  }))
+}
+
+describe('Article', () => {
+  it('renders each tag as a Button, not a bare underlined link', () => {
+    render(
+      <Article
+        article={buildArticle()}
+        recommendations={buildRecommendations(5)}
+      />
+    )
+
+    const tagButton = screen.getByRole('link', {
+      name: 'fields.biology',
+    })
+    // The Button primitive renders via a `render={<Link ... />}` prop,
+    // so the resulting element keeps the anchor's "link" role and its
+    // own `data-slot="button"` — the old markup was a plain,
+    // unstyled-by-Button <p> inside that same <Link>.
+    expect(tagButton).toHaveAttribute('data-slot', 'button')
+    expect(tagButton.closest('.not-prose')).toBeTruthy()
+  })
+
+  it('falls back to the raw tag when no translation exists for it', () => {
+    render(
+      <Article
+        article={buildArticle()}
+        recommendations={buildRecommendations(5)}
+      />
+    )
+
+    expect(
+      screen.getByRole('link', { name: 'Made Up Tag' })
+    ).toBeInTheDocument()
+  })
+
+  it('wraps every avatar image in a fixed-size, object-cover, not-prose box', () => {
+    render(
+      <Article
+        article={buildArticle()}
+        recommendations={buildRecommendations(5)}
+      />
+    )
+
+    const avatarImages = screen
+      .getAllByRole('img')
+      .filter((img) =>
+        img.getAttribute('src')?.includes('headshot.jpg')
+      )
+    // One in the byline, one in the "About the Author" block.
+    expect(avatarImages).toHaveLength(2)
+    avatarImages.forEach((img) => {
+      expect(img).toHaveClass('object-cover')
+      const box = img.parentElement
+      expect(box).toHaveClass(
+        'not-prose',
+        'overflow-hidden'
+      )
+    })
+  })
+
+  it('renders the recommendations as carousel slides', () => {
+    render(
+      <Article
+        article={buildArticle()}
+        recommendations={buildRecommendations(5)}
+      />
+    )
+
+    const slides = document.querySelectorAll(
+      '[data-slot="carousel-item"]'
+    )
+    expect(slides).toHaveLength(5)
+    expect(
+      screen.getByRole('link', { name: /Recommendation 0/ })
+    ).toHaveAttribute('href', '/article/rec-0')
+  })
+})

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,1 +1,41 @@
 import '@testing-library/jest-dom/vitest'
+
+// jsdom doesn't implement matchMedia; embla-carousel-react (used by
+// components/ui/carousel.jsx) calls it unconditionally on mount to watch
+// for reduced-motion / RTL media queries, so any jsdom test that mounts a
+// <Carousel> needs this stub.
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })
+}
+
+// Same gap for Resize/IntersectionObserver — embla watches container and
+// slide visibility changes with both, and jsdom implements neither.
+if (
+  typeof window !== 'undefined' &&
+  !window.ResizeObserver
+) {
+  window.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}
+if (
+  typeof window !== 'undefined' &&
+  !window.IntersectionObserver
+) {
+  window.IntersectionObserver = class IntersectionObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}


### PR DESCRIPTION
- prismicImageLoader: derive crop height from the requested width's aspect ratio instead of a fixed height, so a shared loader instance no longer distorts avatars/thumbnails requested at a different size or DPR than the loader was tuned for.
- article/[slug]: give the cover image, avatars, and recommendation thumbnails their own aspect-correct loader instances, wrap avatars in a fixed-size not-prose/object-cover box (typography's prose img margin was clipping the fill-positioned circle), replace the tag pills with the same field-filter Button used on /articles instead of a plain <p> that inherited prose's underlined link styling, drop prose-sm on mobile and darken the byline caption for contrast against the green background, and replace the hand-rolled "More on this topic" scroller (broken index bookkeeping, no touch scrolling) with shadcn's Carousel.
- add components/ui/carousel.jsx (shadcn, embla-carousel-react) and matchMedia/ResizeObserver/IntersectionObserver jsdom stubs it needs under test.
- tests: prismicImageLoader aspect-ratio regression cases, and a new article page test covering the button/avatar/carousel fixes.