### PR TITLE
fix: mobile layout and spacing issues

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -46,7 +46,7 @@ export default function Footer() {
           </svg>
           <div className="bg-sciteensGreen-regular px-10 pb-8 pt-4 text-gray-100 md:px-24">
             <div className="mr-0 flex flex-col justify-between md:flex-row lg:mr-12">
-              <div className="w-1/8 mb-8 md:mb-0">
+              <div className="md:w-1/8 mb-8 w-full md:mb-0">
                 <p className="mb-1 font-semibold text-white md:mb-2">
                   {i18n.t('footer.organization')}
                 </p>
@@ -86,7 +86,7 @@ export default function Footer() {
                   </li>
                 </ul>
               </div>
-              <div className="w-1/8 mb-8 md:mb-0">
+              <div className="md:w-1/8 mb-8 w-full md:mb-0">
                 <p className="mb-1 font-semibold text-white md:mb-2">
                   {i18n.t('footer.legal')}
                 </p>
@@ -108,7 +108,7 @@ export default function Footer() {
                   </li>
                 </ul>
               </div>
-              <div className="w-1/8 mb-8 md:mb-0">
+              <div className="md:w-1/8 mb-8 w-full md:mb-0">
                 <p className="mb-1 font-semibold text-white md:mb-2">
                   {i18n.t('footer.language')}
                 </p>
@@ -147,18 +147,18 @@ export default function Footer() {
                   </li>
                 </ul>
               </div>
-              <div className="w-1/8 mb-8 md:mb-0">
+              <div className="md:w-1/8 mb-8 w-full md:mb-0">
                 <p className="mb-2 font-semibold text-white">
                   {i18n.t('footer.follow_us')}
                 </p>
-                <div className="flex flex-row">
+                <div className="flex flex-row gap-4">
                   <a
                     href="https://www.facebook.com/SciTeensinfo"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
                     <Image
-                      className="mr-4 h-6 w-auto"
+                      className="h-6 w-auto"
                       src="/assets/icons/facebook-flat.svg"
                       alt="Facebook"
                       width={24}
@@ -172,7 +172,7 @@ export default function Footer() {
                     rel="noopener noreferrer"
                   >
                     <Image
-                      className="mr-4 h-6 w-auto"
+                      className="h-6 w-auto"
                       src="/assets/icons/instagram.svg"
                       alt="Instagram"
                       width={24}
@@ -186,7 +186,7 @@ export default function Footer() {
                     rel="noopener noreferrer"
                   >
                     <Image
-                      className="mr-4 h-6 w-auto"
+                      className="h-6 w-auto"
                       src="/assets/icons/linkedin-flat.svg"
                       alt="LinkedIn"
                       width={26}
@@ -200,7 +200,7 @@ export default function Footer() {
                     rel="noopener noreferrer"
                   >
                     <Image
-                      className="mr-4 h-6 w-auto"
+                      className="h-6 w-auto"
                       src="/assets/icons/youtube.svg"
                       alt="YouTube"
                       width={24}
@@ -214,7 +214,7 @@ export default function Footer() {
                     rel="noopener noreferrer"
                   >
                     <Image
-                      className="mr-4 h-6 w-auto"
+                      className="h-6 w-auto"
                       src="/assets/icons/tiktok.svg"
                       alt="TikTok"
                       width={24}

--- a/components/ui/skeleton.jsx
+++ b/components/ui/skeleton.jsx
@@ -1,0 +1,16 @@
+import { cn } from '@/lib/utils'
+
+function Skeleton({ className, ...props }) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn(
+        'bg-muted animate-pulse rounded-md',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -397,29 +397,33 @@ function Articles({ cached_articles }) {
           </h1>
           <form
             onSubmit={(e) => handleSearch(e)}
-            className="flex flex-row lg:hidden"
+            className="flex flex-col gap-2 lg:hidden"
           >
-            <Button
-              type="submit"
-              size="icon"
-              onClick={(e) => handleSearch(e)}
-            >
-              <Search
-                aria-hidden="true"
-                className="h-5 w-5"
+            <div className="flex flex-row gap-2">
+              <Button
+                type="submit"
+                size="icon"
+                onClick={(e) => handleSearch(e)}
+              >
+                <Search
+                  aria-hidden="true"
+                  className="h-5 w-5"
+                />
+              </Button>
+              <Input
+                onChange={(e) =>
+                  handleChange(e, 'searchbar')
+                }
+                value={search}
+                name="search"
+                placeholder="Search..."
+                required
+                type="text"
+                aria-label="search"
+                maxLength="100"
+                className="bg-card border-gray-300 shadow-sm"
               />
-            </Button>
-            <Input
-              onChange={(e) => handleChange(e, 'searchbar')}
-              value={search}
-              name="search"
-              placeholder="Search..."
-              required
-              type="text"
-              aria-label="search"
-              maxLength="100"
-              className="bg-card border-gray-300 shadow-sm"
-            />
+            </div>
             <Select
               name="field"
               value={field}
@@ -427,7 +431,10 @@ function Articles({ cached_articles }) {
                 handleFieldSearch(value)
               }
             >
-              <SelectTrigger id="field" className="w-1/2">
+              <SelectTrigger
+                id="field"
+                className="bg-card w-full border-gray-300 shadow-sm"
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/pages/profile/[slug]/index.js
+++ b/pages/profile/[slug]/index.js
@@ -39,6 +39,7 @@ import { useSigninCheck } from '../../../context/AuthContext'
 import { AppContext } from '../../../context/context'
 import File from '../../../components/File'
 import ProjectCard from '../../../components/ProjectCard'
+import { Skeleton } from '../../../components/ui/skeleton'
 import { normalizeProject } from '../../../lib/projects'
 
 function Project({ profile }) {
@@ -46,7 +47,10 @@ function Project({ profile }) {
   const router = useRouter()
 
   const [files, setFiles] = useState([])
+  const [filesLoading, setFilesLoading] = useState(true)
   const [projects, setProjects] = useState([])
+  const [projectsLoading, setProjectsLoading] =
+    useState(true)
   const { status, data: signInCheckResult } =
     useSigninCheck()
   const { profile: current_user_profile } =
@@ -73,6 +77,7 @@ function Project({ profile }) {
         )
       })
       setProjects(ps)
+      setProjectsLoading(false)
 
       const filesRef = ref(
         storage,
@@ -80,23 +85,45 @@ function Project({ profile }) {
       )
       try {
         const res = await listAll(filesRef)
-        for (let r of res.items) {
+        const fetchFileBlob = async (r) => {
           const url = await getDownloadURL(r)
           const metadata = await getMetadata(r)
-          const xhr = new XMLHttpRequest()
-          xhr.responseType = 'blob'
-          xhr.onload = () => {
-            const blob = xhr.response
-            if (xhr.status == 200) {
-              blob.name = metadata.name
-              setFiles((fs) => [...fs, blob])
+          return new Promise((resolve, reject) => {
+            const xhr = new XMLHttpRequest()
+            xhr.responseType = 'blob'
+            xhr.onload = () => {
+              if (xhr.status == 200) {
+                const blob = xhr.response
+                blob.name = metadata.name
+                resolve(blob)
+              } else {
+                reject(
+                  new Error(
+                    `Failed to fetch file: ${xhr.status}`
+                  )
+                )
+              }
             }
-          }
-          xhr.open('GET', url)
-          xhr.send()
+            xhr.onerror = () =>
+              reject(
+                new Error('Network error fetching file')
+              )
+            xhr.open('GET', url)
+            xhr.send()
+          })
         }
+        const results = await Promise.allSettled(
+          res.items.map(fetchFileBlob)
+        )
+        setFiles(
+          results
+            .filter((r) => r.status === 'fulfilled')
+            .map((r) => r.value)
+        )
       } catch (e) {
         console.error(e)
+      } finally {
+        setFilesLoading(false)
       }
     }
 
@@ -163,7 +190,9 @@ function Project({ profile }) {
                 </p>
               </div>
             </div>
-            {status === 'success' &&
+            {status !== 'success' ? (
+              <Skeleton className="h-1/3 w-20 rounded-lg" />
+            ) : (
               signInCheckResult.signedIn &&
               current_user_profile?.slug ===
                 router.query?.slug && (
@@ -173,7 +202,8 @@ function Project({ profile }) {
                 >
                   Edit
                 </Link>
-              )}
+              )
+            )}
           </div>
           <h4>
             {t('index_profile.joined')}{' '}
@@ -203,7 +233,12 @@ function Project({ profile }) {
         <h2 className="mb-2 text-lg font-semibold md:text-2xl">
           Projects
         </h2>
-        {projects?.length != 0 ? (
+        {projectsLoading ? (
+          <div className="flex flex-col gap-6 md:gap-8">
+            <Skeleton className="h-24 w-full md:h-40" />
+            <Skeleton className="h-24 w-full md:h-40" />
+          </div>
+        ) : projects?.length != 0 ? (
           projectsComponent
         ) : (
           <p className="text-muted-foreground">
@@ -214,17 +249,22 @@ function Project({ profile }) {
 
       {/* Files */}
       <div className="mx-auto mb-4 mt-12 w-5/6 md:w-2/3 lg:w-1/2">
-        {files.length > 0 && (
+        {(filesLoading || files.length > 0) && (
           <h2 className="mb-2 text-lg font-semibold md:text-2xl">
             Files
           </h2>
         )}
         <div className="flex flex-col items-center space-y-2">
-          {files.map((f, id) => {
-            return (
+          {filesLoading ? (
+            <>
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </>
+          ) : (
+            files.map((f, id) => (
               <File file={f} id={id} key={f.name}></File>
-            )
-          })}
+            ))
+          )}
         </div>
       </div>
     </>


### PR DESCRIPTION
- articles: put category select on its own line on mobile, match bg-card background, add gap-2 spacing in the filter form
- footer: fix zero-gap social icons (margin on nested img didn't expand the shrink-to-fit anchor) via gap-4 on the container; make footer columns full-width on mobile so links no longer wrap mid-word
- profile: add loading skeletons for projects/files/edit button and batch file fetches to eliminate layout shift when navigating into a profile