### PR TITLE
feat: standalone Docker build on Node 22, clean up GCP deployment, ad…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,36 @@
 .dockerignore
+.gitignore
+.gcloudignore
+
+# dependencies
 node_modules
-npm-debug.log
-pnpm-debug.log
 .pnpm-store
+
+# next.js build output
+.next
+.next-e2e-*
+out
+
+# testing
+coverage
+test-results
+playwright-report
+playwright/.cache
+
+# misc
+.DS_Store
+*.pem
+*.log
+firebase-debug.log
+firestore-debug.log
+ui-debug.log
+
+# firebase
+.firebaserc
+.firebase
+
+# vercel
+.vercel
+
+# ide
+.vscode

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -1,0 +1,36 @@
+name: Deploy Cloud Functions
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'functions/**'
+      - 'firebase.json'
+      - '.github/workflows/deploy-functions.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-functions
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: pnpm/action-setup@v4
+
+      - run: pnpm install --frozen-lockfile
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+
+      - name: Deploy functions
+        run: npx firebase-tools deploy --only functions --project directed-relic-266701

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Install dependencies only when needed
-FROM node:20-alpine AS deps
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+FROM node:22-alpine AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@8.15.9 --activate
@@ -9,18 +8,16 @@ COPY functions/package.json ./functions/package.json
 RUN pnpm install --frozen-lockfile --filter sciteens...
 
 # Rebuild the source code only when needed
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
-ARG NODE_ENV
+ARG NODE_ENV=production
 ARG NEXT_PUBLIC_FB_PROJECT_ID
 ARG NEXT_PUBLIC_FB_API_KEY
 ARG NEXT_PUBLIC_FB_MESSAGING_SENDER_ID
 ARG NEXT_PUBLIC_FB_APP_ID
 ARG NEXT_PUBLIC_FB_MEASUREMENT_ID
 ARG NEXT_PUBLIC_AL_APP_ID
-ARG AL_ADMIN_KEY
 ARG NEXT_PUBLIC_AL_SEARCH_KEY
-ARG NEXT_PUBLIC_GC_GRADE
 
 ENV NODE_ENV=${NODE_ENV}
 ENV NEXT_PUBLIC_FB_PROJECT_ID=${NEXT_PUBLIC_FB_PROJECT_ID}
@@ -29,44 +26,31 @@ ENV NEXT_PUBLIC_FB_MESSAGING_SENDER_ID=${NEXT_PUBLIC_FB_MESSAGING_SENDER_ID}
 ENV NEXT_PUBLIC_FB_APP_ID=${NEXT_PUBLIC_FB_APP_ID}
 ENV NEXT_PUBLIC_FB_MEASUREMENT_ID=${NEXT_PUBLIC_FB_MEASUREMENT_ID}
 ENV NEXT_PUBLIC_AL_APP_ID=${NEXT_PUBLIC_AL_APP_ID}
-ENV AL_ADMIN_KEY=${AL_ADMIN_KEY}
 ENV NEXT_PUBLIC_AL_SEARCH_KEY=${NEXT_PUBLIC_AL_SEARCH_KEY}
-ENV NEXT_PUBLIC_GC_GRADE=${NEXT_PUBLIC_GC_GRADE}
+ENV NEXT_TELEMETRY_DISABLED=1
+
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
 RUN corepack enable && corepack prepare pnpm@8.15.9 --activate && pnpm run build
 
-# Production image, copy all the files and run next
-FROM node:20-alpine AS runner
+# Production image, copy only the standalone output
+FROM node:22-alpine AS runner
 WORKDIR /app
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN addgroup -g 1001 -S nodejs
 RUN adduser -S nextjs -u 1001
 
-# You only need to copy next.config.js if you are NOT using the default configuration
-COPY --from=builder /app/next.config.js ./
-COPY --from=builder /app/next-i18next.config.js ./
-COPY --from=builder /app/htmlserializer.js ./
-COPY --from=builder /app/tailwind.config.js ./
-COPY --from=builder /app/firebaseConfig.js ./
-COPY --from=builder /app/postcss.config.js ./
-COPY --from=builder /app/public ./public
-COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/package.json ./package.json
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 
 USER nextjs
 
 EXPOSE 3000
 
-ENV PORT 3000
-
-# Next.js collects completely anonymous telemetry data about general usage.
-# Learn more here: https://nextjs.org/telemetry
-# Uncomment the following line in case you want to disable telemetry.
-# ENV NEXT_TELEMETRY_DISABLED 1
-
-CMD ["node_modules/.bin/next", "start"]
-# CMD ["node", "server.js"]
+CMD ["node", "server.js"]

--- a/cloud-build.yaml
+++ b/cloud-build.yaml
@@ -32,11 +32,7 @@ steps:
         '--build-arg',
         'NEXT_PUBLIC_AL_APP_ID=${_NEXT_PUBLIC_AL_APP_ID}',
         '--build-arg',
-        'AL_ADMIN_KEY=${_AL_ADMIN_KEY}',
-        '--build-arg',
         'NEXT_PUBLIC_AL_SEARCH_KEY=${_NEXT_PUBLIC_AL_SEARCH_KEY}',
-        '--build-arg',
-        'NEXT_PUBLIC_GC_GRADE=${_NEXT_PUBLIC_GC_GRADE}',
       ]
   - name: 'gcr.io/cloud-builders/docker'
     args:
@@ -59,8 +55,19 @@ steps:
         'managed',
         '--port',
         '3000',
-        '--set-env-vars',
-        'AL_ADMIN_KEY=${_AL_ADMIN_KEY}',
+        '--memory',
+        '1Gi',
+        '--cpu',
+        '1',
+        '--min-instances',
+        '1',
+        '--max-instances',
+        '10',
+        '--concurrency',
+        '80',
+        '--timeout',
+        '300',
+        '--allow-unauthenticated',
       ]
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: gcloud

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,8 @@
 {
+  "functions": {
+    "source": "functions",
+    "runtime": "nodejs22"
+  },
   "firestore": {
     "rules": "firestore.rules"
   },

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "dependencies": {
     "@google-cloud/vision": "^2.4.2",

--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -1,4 +1,4 @@
 module.exports = {
-  siteUrl: 'https://sciteens.com',
+  siteUrl: 'https://sciteens.org',
   generateRobotsTxt: true,
 }

--- a/next.config.js
+++ b/next.config.js
@@ -55,6 +55,7 @@ const connectSrc = [
 ].join(' ')
 
 module.exports = {
+  output: 'standalone',
   // Isolates webpack's persistent cache per Firebase config —
   // without this, two `next dev` processes sharing distDir can leak
   // a client bundle compiled under the other config (see


### PR DESCRIPTION
…d functions CI

- Rewrite Dockerfile for Next.js standalone output on Node 22
- Add output: 'standalone' to next.config.js
- Update next-sitemap.js siteUrl to sciteens.org
- Rewrite cloud-build.yaml: remove stale build args (AL_ADMIN_KEY, NEXT_PUBLIC_GC_GRADE, NEXT_PUBLIC_GM_API_KEY), add Cloud Run deploy flags (memory, cpu, min/max instances, concurrency, timeout, allow-unauthenticated)
- Expand .dockerignore to exclude build artifacts and logs
- Bump functions/package.json node engine to 22
- Add functions config to firebase.json (runtime nodejs22)
- Add GitHub Actions workflow to deploy functions on push to main