### PR TITLE
fix: add --force to functions deploy for cleanup policy

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -33,4 +33,4 @@ jobs:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
 
       - name: Deploy functions
-        run: npx firebase-tools deploy --only functions --project directed-relic-266701
+        run: npx firebase-tools deploy --only functions --project directed-relic-266701 --force


### PR DESCRIPTION
## What changed

Adds `--force` to the `firebase deploy --only functions` command in the deploy-functions workflow. Without it, the deploy fails on the artifact cleanup policy setup step, even though all functions deploy successfully.

## Why

Firebase deploy tries to set up an artifact registry cleanup policy after deploying functions. Without `--force`, it errors out with `Functions successfully deployed but could not set up cleanup policy`. The `--force` flag auto-creates the cleanup policy instead of failing.

## Validation

Will be validated by re-running the workflow after merge. The `cloudscheduler.admin` role has also been granted to the deploy service account on GCP to fix the scheduled functions (updateUserStats, scheduledProgramEmailer) deploy failure.