### PR TITLE
fix: mobile nav spacing, sticky footer, and header consistency

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import dynamic from 'next/dynamic'
 import Banner from '../components/Banner'
 import MyPageViewLogger from './Analytics'
@@ -11,10 +11,31 @@ const Footer = dynamic(() => import('./Footer'), {
   ssr: false,
 })
 
+// Matches the nav's rendered height (mt-3 + h-16) when no banner is
+// showing, so the content doesn't jump on first paint.
+const DEFAULT_NAV_HEIGHT = 76
+
 export default function Layout({ children }) {
   const [visibleNav, setVisibleNav] = useState(true)
   const [visibleBanner, setVisibleBanner] = useState(true)
+  const navWrapRef = useRef(null)
+  const [navHeight, setNavHeight] = useState(
+    DEFAULT_NAV_HEIGHT
+  )
 
+  useEffect(() => {
+    const node = navWrapRef.current
+    if (!node || typeof ResizeObserver === 'undefined')
+      return
+
+    const observer = new ResizeObserver((entries) => {
+      const height = entries[0]?.contentRect.height
+      if (height) setNavHeight(height)
+    })
+    observer.observe(node)
+
+    return () => observer.disconnect()
+  }, [])
   useEffect(() => {
     let previousY = document.documentElement.scrollTop
 
@@ -59,6 +80,7 @@ export default function Layout({ children }) {
   return (
     <>
       <div
+        ref={navWrapRef}
         className={`fixed z-50 w-full transform transition-all duration-300 ${
           visibleNav ? 'translate-y-0' : '-translate-y-32'
         }`}
@@ -69,7 +91,8 @@ export default function Layout({ children }) {
         <NavBar />
       </div>
       <div
-        className={`${visibleBanner ? 'pt-52' : 'pt-20'}`}
+        className="flex-1"
+        style={{ paddingTop: navHeight }}
       >
         {children}
       </div>

--- a/components/PageHeading.jsx
+++ b/components/PageHeading.jsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/utils'
+
+// Shared page-title treatment (weight + responsive scale) matching the
+// homepage hero, so top-level pages (Articles, Projects, About, ...)
+// no longer drift to their own one-off heading sizes.
+export default function PageHeading({
+  as: Tag = 'h1',
+  children,
+  className,
+}) {
+  return (
+    <Tag
+      className={cn(
+        'text-3xl font-extrabold md:text-4xl lg:text-5xl',
+        className
+      )}
+    >
+      {children}
+    </Tag>
+  )
+}

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import PageHeading from '@/components/PageHeading'
 
 export default function FourOhFour() {
   return (
@@ -13,9 +14,9 @@ export default function FourOhFour() {
           height={462}
           className="mx-auto h-auto w-1/2"
         />
-        <h1 className="py-4 text-4xl font-semibold">
+        <PageHeading className="py-4">
           Page not found
-        </h1>
+        </PageHeading>
         <p className="mb-6 text-xl">
           This page may not exist or may have been deleted.
         </p>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -63,7 +63,7 @@ function MyApp({ Component, pageProps }) {
 
   return (
     <div
-      className={`${nunito.variable} bg-background font-sciteens text-foreground min-h-screen w-full`}
+      className={`${nunito.variable} bg-background font-sciteens text-foreground flex min-h-screen w-full flex-col`}
     >
       <Head>
         <title>Welcome to SciTeens</title>

--- a/pages/about.js
+++ b/pages/about.js
@@ -3,6 +3,7 @@ import Image from 'next/image'
 import { useEffect, useState } from 'react'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
+import PageHeading from '@/components/PageHeading'
 
 export default function About() {
   const { t } = useTranslation('common')
@@ -235,9 +236,9 @@ export default function About() {
       </Head>
       <main>
         <div className="mx-auto w-full px-4 py-8 text-left md:p-8 lg:w-5/6">
-          <h1 className="my-4 text-center text-3xl font-semibold md:text-5xl">
+          <PageHeading className="my-4 text-center">
             {t('about.on_a_mission')}
-          </h1>
+          </PageHeading>
           <p className="mx-0 mb-12 text-center text-base md:text-xl lg:mx-24">
             {t('about.we_strive')}
           </p>

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
 import { useIntersectionObserver } from '../context/helpers'
+import PageHeading from '@/components/PageHeading'
 
 var Prismic = require('@prismicio/client')
 import { RichText } from 'prismic-reactjs'
@@ -392,9 +393,9 @@ function Articles({ cached_articles }) {
       </Head>
       <div className="text-foreground mx-auto mb-24 mt-8 flex min-h-screen flex-row overflow-x-hidden md:overflow-visible lg:mx-16 xl:mx-32">
         <div className="mx-auto w-11/12 md:w-[85%] lg:mx-0 lg:w-[60%]">
-          <h1 className="ml-4 py-4 text-left text-4xl font-semibold">
+          <PageHeading className="ml-4 py-4 text-left">
             {t('articles.articles')} 📰
-          </h1>
+          </PageHeading>
           <form
             onSubmit={(e) => handleSearch(e)}
             className="flex flex-col gap-2 lg:hidden"

--- a/pages/courses.js
+++ b/pages/courses.js
@@ -14,6 +14,7 @@ import moment from 'moment'
 import { getTranslatedFieldsDict } from '../context/helpers'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import PageHeading from '@/components/PageHeading'
 
 function Courses({ cached_courses }) {
   const router = useRouter()
@@ -179,9 +180,9 @@ function Courses({ cached_courses }) {
       </Head>
       <div className="text-foreground mx-auto mb-24 mt-8 flex min-h-screen flex-row overflow-x-hidden md:overflow-visible lg:mx-16 xl:mx-32">
         <div className="mx-auto w-11/12 md:w-[85%] lg:mx-0 lg:w-[60%]">
-          <h1 className="ml-4 py-4 text-left text-4xl font-semibold">
+          <PageHeading className="ml-4 py-4 text-left">
             {t('courses.courses')} 📖
-          </h1>
+          </PageHeading>
           {coursesComponent}
           {courses.results.length == 0 && (
             <div className="mx-auto mt-20 text-center">

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -3,6 +3,7 @@ import Image from 'next/image'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
 import Head from 'next/head'
+import PageHeading from '@/components/PageHeading'
 
 export default function Donate() {
   const { t } = useTranslation('common')
@@ -27,9 +28,9 @@ export default function Donate() {
       </Head>
       <div className="w-full">
         <div className="mx-auto w-full px-4 py-8 text-left md:p-8 lg:w-2/3">
-          <h1 className="text-4xl">
+          <PageHeading>
             {t('donate.annual_donation_appeal')}
-          </h1>
+          </PageHeading>
           <div className="mb-8 mt-4 flex w-full flex-row">
             <a
               href="https://www.paypal.com/donate?hosted_button_id=7B8QACYV83ACA"

--- a/pages/getinvolved.js
+++ b/pages/getinvolved.js
@@ -7,6 +7,7 @@ import {
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
 import Head from 'next/head'
+import PageHeading from '@/components/PageHeading'
 
 export default function GetInvolved() {
   const { t } = useTranslation('common')
@@ -41,9 +42,9 @@ export default function GetInvolved() {
       </Head>
       <div>
         <div className="mx-auto w-full px-4 py-8 text-left md:p-8 lg:w-5/6">
-          <h1 className="my-4 mb-10 text-center text-3xl font-semibold md:text-5xl">
+          <PageHeading className="my-4 mb-10 text-center">
             {t('get_involved.want_to_get_involved')}
-          </h1>
+          </PageHeading>
           <div className="flex flex-col">
             <animated.div
               style={cardsTrail[0]}

--- a/pages/legal/gdpr.js
+++ b/pages/legal/gdpr.js
@@ -1,5 +1,6 @@
 import Head from 'next/head'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import PageHeading from '@/components/PageHeading'
 
 export default function gdpr() {
   return (
@@ -86,7 +87,7 @@ export default function gdpr() {
             </div>
           </div>
           <div className="mx-8 md:mx-12 lg:mx-0 lg:w-2/3">
-            <h1 className="text-3xl">COOKIE POLICY</h1>
+            <PageHeading>COOKIE POLICY</PageHeading>
             <p className="mb-8 mt-1 whitespace-pre-line text-gray-700">
               Last Updated 9/30/2021
             </p>

--- a/pages/legal/privacy.js
+++ b/pages/legal/privacy.js
@@ -1,5 +1,6 @@
 import Head from 'next/head'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import PageHeading from '@/components/PageHeading'
 
 export default function privacy() {
   return (
@@ -154,7 +155,7 @@ export default function privacy() {
             </div>
           </div>
           <div className="mx-8 md:mx-12 lg:mx-0 lg:w-2/3">
-            <h1 className="text-3xl">PRIVACY POLICY</h1>
+            <PageHeading>PRIVACY POLICY</PageHeading>
             <p className="mb-8 mt-1 whitespace-pre-line text-gray-700">
               Last Updated 9/30/2021
             </p>

--- a/pages/legal/terms.js
+++ b/pages/legal/terms.js
@@ -1,5 +1,6 @@
 import Head from 'next/head'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import PageHeading from '@/components/PageHeading'
 
 export default function terms() {
   return (
@@ -221,7 +222,7 @@ export default function terms() {
             </div>
           </div>
           <div className="mx-8 md:mx-12 lg:mx-0 lg:w-2/3">
-            <h1 className="text-3xl">TERMS OF USE</h1>
+            <PageHeading>TERMS OF USE</PageHeading>
             <p className="mb-8 mt-1 whitespace-pre-line text-gray-700">
               Last Updated 9/30/2021
             </p>

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -7,6 +7,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
 import { useIntersectionObserver } from '../context/helpers'
 import { getTranslatedFieldsDict } from '../context/helpers'
+import PageHeading from '@/components/PageHeading'
 
 import { db as firestore } from '../lib/firebase'
 import firebaseConfig from '../firebaseConfig'
@@ -356,9 +357,9 @@ function Projects({ cached_projects }) {
       <div className="text-foreground mx-auto mb-24 mt-8 flex min-h-screen flex-row overflow-x-hidden md:overflow-visible lg:mx-16 xl:mx-32">
         <div className="mx-auto w-11/12 md:w-[85%] lg:mx-0 lg:w-[60%]">
           <div className="flex flex-row justify-between">
-            <h1 className="ml-0 py-4 text-left text-3xl font-semibold md:ml-4 md:text-4xl">
+            <PageHeading className="ml-0 py-4 text-left md:ml-4">
               {t('projects.projects')} 🔬
-            </h1>
+            </PageHeading>
             <Link
               href="/project/create"
               className="border-sciteensLightGreen-regular text-sciteensLightGreen-regular hover:border-sciteensLightGreen-dark hover:text-sciteensLightGreen-dark my-auto inline-flex items-center rounded-lg border-2 px-3 py-1.5 no-underline shadow-sm transition md:px-5 md:text-lg"


### PR DESCRIPTION
- Layout: measure the fixed nav+banner wrapper via ResizeObserver and use its real height for content padding-top instead of hardcoded pt-52/pt-20, which assumed a banner was always showing and left a large dead gap above content (worst on mobile, on pages like Articles/Projects/Courses).
- _app: turn the root wrapper into a flex column and give Layout's content area flex-1 so the footer sticks to the true bottom of the viewport instead of floating above empty space on short pages.
- Add components/PageHeading, a shared page-title style (extrabold, responsive text-3xl/md:text-4xl/lg:text-5xl) matching the homepage hero, and use it on Articles, Projects, Courses, About, Get Involved, Donate, 404, and the legal pages, replacing seven divergent one-off heading styles.