### PR TITLE
fix: e2e test failures (articles hydration, birthday calendar, signin…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,11 +94,8 @@ jobs:
       # during teardown, triggering an OOM SIGKILL after all tests pass.
       # 4GB swap gives headroom for the spike without slowing tests
       # (working set fits in RAM; only teardown touches swap).
-      - name: Add swap space
-        run: |
-          sudo fallocate -l 4G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
+      - uses: pierotofy/set-swap-space@v1
+        with:
+          swap-size-gb: 4
       # "live" project needs real Firebase secrets, not wired in CI yet.
       - run: pnpm exec playwright test --project=emulator

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
       # during teardown, triggering an OOM SIGKILL after all tests pass.
       # 4GB swap gives headroom for the spike without slowing tests
       # (working set fits in RAM; only teardown touches swap).
-      - uses: pierotofy/set-swap-space@v1
+      - uses: pierotofy/set-swap-space@v1.0
         with:
           swap-size-gb: 4
       # "live" project needs real Firebase secrets, not wired in CI yet.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,4 +98,4 @@ jobs:
         with:
           swap-size-gb: 4
       # "live" project needs real Firebase secrets, not wired in CI yet.
-      - run: pnpm exec playwright test --project=emulator
+      - run: npx playwright test --project=emulator

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,5 +89,16 @@ jobs:
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: firebase-emulators-${{ runner.os }}-
+      # GitHub-hosted runners have 7GB RAM and no swap. The Firestore
+      # emulator JVM, next dev, and Chromium together peak above that
+      # during teardown, triggering an OOM SIGKILL after all tests pass.
+      # 4GB swap gives headroom for the spike without slowing tests
+      # (working set fits in RAM; only teardown touches swap).
+      - name: Add swap space
+        run: |
+          sudo fallocate -l 4G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
       # "live" project needs real Firebase secrets, not wired in CI yet.
       - run: pnpm exec playwright test --project=emulator

--- a/e2e/global-teardown.js
+++ b/e2e/global-teardown.js
@@ -1,6 +1,11 @@
 // Belt-and-suspenders: the Firestore emulator's Java process runs
 // detached and can survive Playwright's process-tree kill, orphaning
 // the port. Best-effort, never fails the run.
+//
+// -sTCP:LISTEN restricts to processes *listening* on the port (the
+// JVM), not those with active connections (the Playwright process
+// itself, which holds an admin-SDK gRPC channel to the emulator).
+// Without this filter, globalTeardown would SIGKILL its own process.
 const { execSync } = require('node:child_process')
 const {
   FIRESTORE_EMULATOR_PORT,
@@ -13,9 +18,12 @@ module.exports = async function globalTeardown() {
     AUTH_EMULATOR_PORT,
   ]) {
     try {
-      const pids = execSync(`lsof -ti:${port}`, {
-        stdio: ['ignore', 'pipe', 'ignore'],
-      })
+      const pids = execSync(
+        `lsof -ti:${port} -sTCP:LISTEN`,
+        {
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }
+      )
         .toString()
         .split('\n')
         .map((line) => line.trim())

--- a/e2e/i18n-smoke.spec.js
+++ b/e2e/i18n-smoke.spec.js
@@ -18,18 +18,6 @@ test.describe('i18n smoke', () => {
       test(`${path} has no missing keys or errors in ${locale}`, async ({
         page,
       }) => {
-        // KNOWN ISSUE, not caused by this test: /articles reliably
-        // hydration-fails under `next dev` in every locale (not a
-        // moment.js locale race, not concurrency-specific — root
-        // cause not pinned down, suspect useWindowVirtualizer racing
-        // /articles' live external CMS data). Tracked via test.fail()
-        // so it flips to a build failure once someone actually fixes
-        // it.
-        test.fail(
-          path === '/articles',
-          'Known /articles hydration-mismatch bug, not yet root-caused — see comment above'
-        )
-
         const missingKeyLogs = []
         const pageErrors = []
 

--- a/e2e/project-flow.spec.js
+++ b/e2e/project-flow.spec.js
@@ -14,6 +14,7 @@ const {
   getProjectInvite,
   setProjectFields,
 } = require('./support/admin')
+const { waitForHydration } = require('./support/ui')
 
 const PASSWORD = 'SciTeens!23'
 
@@ -23,14 +24,16 @@ async function signIn(page, { email, password }, ref) {
       ? `/signin/student?ref=${encodeURIComponent(ref)}`
       : '/signin/student'
   )
+  // Wait for React hydration before filling (see support/ui.js).
+  await waitForHydration(page, '#email')
   await page.locator('#email').fill(email)
   await page.locator('#password').fill(password)
-  await page
-    .getByRole('button', {
-      name: 'Sign In',
-      exact: true,
-    })
-    .click()
+  const submit = page.getByRole('button', {
+    name: 'Sign In',
+    exact: true,
+  })
+  await expect(submit).toBeEnabled({ timeout: 15_000 })
+  await submit.click()
 }
 
 test.describe('project create -> invite -> edit', () => {

--- a/e2e/signup-redirect.spec.js
+++ b/e2e/signup-redirect.spec.js
@@ -8,6 +8,7 @@ const {
   uniqueSuffix,
   seedStudent,
 } = require('./support/admin')
+const { waitForHydration } = require('./support/ui')
 
 const PASSWORD = 'SciTeens!23'
 
@@ -16,13 +17,26 @@ test.describe('resolveRefPath redirect end to end', () => {
     page,
   }) => {
     await page.goto('/signup/student')
+    await waitForHydration(page, '#first_name')
     await page.locator('#first_name').fill('Ada')
     await page.locator('#last_name').fill('Lovelace')
     await page
       .locator('#email')
       .fill(`e2e-signup-${uniqueSuffix()}@example.com`)
     await page.locator('#password').fill(PASSWORD)
-    await page.locator('#birthday').fill('2000-01-01')
+    // BirthdayField is a Popover+Calendar, not a native date
+    // input; open it, navigate to January 2000 via the
+    // dropdowns, click day 1.
+    await page.locator('#birthday').click()
+    await page
+      .getByRole('combobox', { name: 'Choose the Year' })
+      .selectOption('2000')
+    await page
+      .getByRole('combobox', { name: 'Choose the Month' })
+      .selectOption({ label: 'Jan' })
+    await page
+      .getByRole('button', { name: /January 1st, 2000/ })
+      .click()
     await page
       .getByRole('checkbox', {
         name: 'I have read and accept',
@@ -33,7 +47,8 @@ test.describe('resolveRefPath redirect end to end', () => {
       name: 'Create Account',
     })
     // Gated on form validity plus the emulator-faked reCAPTCHA
-    // resolving (lib/firebase.js's appVerificationDisabledForTesting).
+    // resolving (lib/firebase.js's
+    // appVerificationDisabledForTesting).
     await expect(submit).toBeEnabled({ timeout: 15_000 })
     await submit.click()
 
@@ -54,14 +69,15 @@ test.describe('resolveRefPath redirect end to end', () => {
     await page.goto(
       `/signin/student?ref=project|${projectId}`
     )
+    await waitForHydration(page, '#email')
     await page.locator('#email').fill(student.email)
     await page.locator('#password').fill(student.password)
-    await page
-      .getByRole('button', {
-        name: 'Sign In',
-        exact: true,
-      })
-      .click()
+    const submit = page.getByRole('button', {
+      name: 'Sign In',
+      exact: true,
+    })
+    await expect(submit).toBeEnabled({ timeout: 15_000 })
+    await submit.click()
 
     await page.waitForURL(`/project/${projectId}`, {
       timeout: 15_000,

--- a/e2e/support/ui.js
+++ b/e2e/support/ui.js
@@ -1,0 +1,17 @@
+// next dev compiles routes on demand; the first visit to a route
+// may not have hydrated when fill() fires its events, so
+// react-hook-form never sees the values and the submit button
+// stays disabled. Wait for React to attach its fiber to an input
+// (only present after hydration) before filling.
+async function waitForHydration(page, selector) {
+  await page.waitForFunction(
+    (sel) =>
+      Object.keys(document.querySelector(sel) || {}).some(
+        (k) => k.startsWith('__reactFiber')
+      ),
+    selector,
+    { timeout: 15_000 }
+  )
+}
+
+module.exports = { waitForHydration }

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -84,6 +84,12 @@ function Articles({ cached_articles }) {
   const router = useRouter()
   const [search, setSearch] = useState('')
   const [field, setField] = useState('All')
+  // useWindowVirtualizer computes getTotalSize() from window
+  // dimensions, which are absent during SSR — rendering it on the
+  // server produces height:0px vs the client's real height, a
+  // hydration mismatch. Defer virtualized rendering to after mount.
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => setMounted(true), [])
 
   const searchParam = router.query?.search || ''
   const fieldParam =
@@ -98,7 +104,6 @@ function Articles({ cached_articles }) {
 
   const initialData = useMemo(() => {
     if (
-      !router.isReady ||
       searchParam ||
       fieldParam ||
       firstPage !== 1 ||
@@ -121,13 +126,7 @@ function Articles({ cached_articles }) {
       ],
       pageParams: [1],
     }
-  }, [
-    router.isReady,
-    searchParam,
-    fieldParam,
-    firstPage,
-    cached_articles,
-  ])
+  }, [searchParam, fieldParam, firstPage, cached_articles])
 
   const articlesQuery = useInfiniteQuery({
     queryKey: [
@@ -262,13 +261,80 @@ function Articles({ cached_articles }) {
 
   const { t } = useTranslation('common')
 
+  function renderArticleCard(article) {
+    const author_image = article.data.body.map(
+      (slice, i) => {
+        if (slice.slice_type == 'about_the_author') {
+          return (
+            <div
+              className="relative h-6 w-6 lg:h-8 lg:w-8"
+              key={i}
+            >
+              <Image
+                alt={`${article.data.author} headshot`}
+                className="h-6 w-6 rounded-full lg:h-8 lg:w-8"
+                height={48}
+                width={48}
+                loader={imageLoader}
+                src={slice.primary.headshot.url}
+              />
+            </div>
+          )
+        } else {
+          return null
+        }
+      }
+    )
+
+    return (
+      <div key={article.id} className="w-full pt-6 md:pt-8">
+        <Link
+          href={`/article/${article.uid}`}
+          className="animate-in bg-card text-card-foreground ring-border/60 fade-in slide-in-from-right-8 z-50 flex cursor-pointer flex-row items-center rounded-xl p-4 shadow-sm ring-1 transition duration-300 hover:-translate-y-0.5 hover:shadow-md"
+        >
+          <div className="relative h-full max-w-[100px] md:max-w-[200px]">
+            <Image
+              alt={RichText.asText(article.data.title)}
+              className="shrink-0 rounded-lg object-cover"
+              loader={imageLoader}
+              src={article.data.image.url}
+              width={256}
+              height={256}
+            />
+          </div>
+          <div className="ml-4 w-3/4 lg:w-11/12">
+            <div className="mb-3 flex flex-row items-center">
+              {author_image}
+              <p className="ml-3">{article.data.author}</p>
+            </div>
+            <h3 className="line-clamp-2 mb-2 text-base font-semibold md:text-xl lg:text-2xl">
+              {RichText.asText(article.data.title)}
+            </h3>
+            <p className="line-clamp-none md:line-clamp-2 mb-2 hidden text-sm md:flex lg:text-base">
+              {article.data.description}
+            </p>
+            <p className="flex text-xs">
+              {(mounted
+                ? moment(article.data.date)
+                    .locale(router?.locale || 'en')
+                    .format('ll')
+                : moment(article.data.date).format('ll')) +
+                ' · ' +
+                readingTime(article.data.text)}
+            </p>
+          </div>
+        </Link>
+      </div>
+    )
+  }
+
   const articleVirtualizer = useWindowVirtualizer({
     count: articles.length,
     estimateSize: () => 340,
     overscan: 5,
   })
 
-  const articlesComponent = (
+  const articlesComponent = mounted ? (
     <div
       className="relative w-full"
       style={{
@@ -281,81 +347,26 @@ function Articles({ cached_articles }) {
           const article = articles[virtualRow.index]
           if (!article) return null
 
-          const author_image = article.data.body.map(
-            (slice, index) => {
-              if (slice.slice_type == 'about_the_author') {
-                return (
-                  <div
-                    className="relative h-6 w-6 lg:h-8 lg:w-8"
-                    key={index}
-                  >
-                    <Image
-                      alt={`${article.data.author} headshot`}
-                      className="h-6 w-6 rounded-full lg:h-8 lg:w-8"
-                      height={48}
-                      width={48}
-                      loader={imageLoader}
-                      src={slice.primary.headshot.url}
-                    />
-                  </div>
-                )
-              } else {
-                return null
-              }
-            }
-          )
-
           return (
             <div
               key={article.id}
               ref={articleVirtualizer.measureElement}
               data-index={virtualRow.index}
-              className="absolute left-0 top-0 w-full pt-6 md:pt-8"
+              className="absolute left-0 top-0 w-full"
               style={{
                 transform: `translateY(${virtualRow.start}px)`,
               }}
             >
-              <Link
-                href={`/article/${article.uid}`}
-                className="animate-in bg-card text-card-foreground ring-border/60 fade-in slide-in-from-right-8 z-50 flex cursor-pointer flex-row items-center rounded-xl p-4 shadow-sm ring-1 transition duration-300 hover:-translate-y-0.5 hover:shadow-md"
-              >
-                <div className="relative h-full max-w-[100px] md:max-w-[200px]">
-                  <Image
-                    alt={RichText.asText(
-                      article.data.title
-                    )}
-                    className="shrink-0 rounded-lg object-cover"
-                    loader={imageLoader}
-                    src={article.data.image.url}
-                    width={256}
-                    height={256}
-                  />
-                </div>
-                <div className="ml-4 w-3/4 lg:w-11/12">
-                  <div className="mb-3 flex flex-row items-center">
-                    {author_image}
-                    <p className="ml-3">
-                      {article.data.author}
-                    </p>
-                  </div>
-                  <h3 className="line-clamp-2 mb-2 text-base font-semibold md:text-xl lg:text-2xl">
-                    {RichText.asText(article.data.title)}
-                  </h3>
-                  <p className="line-clamp-none md:line-clamp-2 mb-2 hidden text-sm md:flex lg:text-base">
-                    {article.data.description}
-                  </p>
-                  <p className="flex text-xs">
-                    {moment(article.data.date)
-                      .locale(router?.locale || 'en')
-                      .format('ll') +
-                      ' · ' +
-                      readingTime(article.data.text)}
-                  </p>
-                </div>
-              </Link>
+              {renderArticleCard(article)}
             </div>
           )
         })}
+    </div>
+  ) : (
+    <div className="relative w-full">
+      {articles.map((article) =>
+        renderArticleCard(article)
+      )}
     </div>
   )
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -37,7 +37,7 @@ const webServer = [
     // GitHub-hosted runners have 7GB total RAM and no swap — the JVM,
     // next dev, and Chromium together peak above that during teardown.
     // Fixture data is a handful of docs, so 512m is generous.
-    command: `pnpm exec firebase emulators:exec --only auth,firestore --project ${EMULATOR_PROJECT_ID} "node e2e/support/hold-open.js"`,
+    command: `node_modules/.bin/firebase emulators:exec --only auth,firestore --project ${EMULATOR_PROJECT_ID} "node e2e/support/hold-open.js"`,
     url: 'http://127.0.0.1:8080',
     reuseExistingServer,
     timeout: 60_000,
@@ -50,7 +50,7 @@ const webServer = [
     // `next dev`, not build+start: build+start didn't fix the known
     // /articles hydration issue (see i18n-smoke.spec.js) and was less
     // stable overall in testing.
-    command: `pnpm exec next dev -p ${EMULATOR_APP_PORT}`,
+    command: `node_modules/.bin/next dev -p ${EMULATOR_APP_PORT}`,
     url: `http://127.0.0.1:${EMULATOR_APP_PORT}`,
     reuseExistingServer,
     timeout: 180_000,

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -34,16 +34,16 @@ const webServer = [
     // `emulators:exec` (not `emulators:start`) for reliable teardown:
     // the Firestore emulator's Java process runs in its own detached
     // session and survives a plain SIGTERM. Capped heap: standard
-    // GitHub-hosted runners have 7GB total RAM and the JVM's default
-    // heap sizing left nothing for `next dev` + Chromium, OOM-killing
-    // the whole run near the end regardless of Playwright's own
-    // `workers` setting (fixture data here is tiny — 1g is generous).
+    // GitHub-hosted runners have 7GB total RAM and no swap — the JVM,
+    // next dev, and Chromium together peak above that during teardown.
+    // Fixture data is a handful of docs, so 512m is generous.
     command: `pnpm exec firebase emulators:exec --only auth,firestore --project ${EMULATOR_PROJECT_ID} "node e2e/support/hold-open.js"`,
     url: 'http://127.0.0.1:8080',
     reuseExistingServer,
     timeout: 60_000,
+    gracefulShutdown: { timeout: 5_000 },
     env: {
-      JAVA_TOOL_OPTIONS: '-Xmx1g',
+      JAVA_TOOL_OPTIONS: '-Xmx512m',
     },
   },
   {
@@ -54,6 +54,7 @@ const webServer = [
     url: `http://127.0.0.1:${EMULATOR_APP_PORT}`,
     reuseExistingServer,
     timeout: 180_000,
+    gracefulShutdown: { timeout: 5_000 },
     env: {
       ...EMULATOR_FIREBASE_CONFIG,
       NEXT_PUBLIC_I18NEXT_DEBUG: 'true',
@@ -62,7 +63,7 @@ const webServer = [
       // dev`'s module graph grows with every distinct route/locale
       // it compiles across the run, so cap it instead of letting V8
       // grow toward the default (much larger) ceiling.
-      NODE_OPTIONS: '--max-old-space-size=1536',
+      NODE_OPTIONS: '--max-old-space-size=1024',
     },
   },
 ]


### PR DESCRIPTION
… race)

Three distinct e2e failures on GitHub Actions:

1. i18n-smoke /articles (all 4 locales): hydration mismatch in pages/articles.js. useWindowVirtualizer.getTotalSize() returns 0px on the server (no window) but 3400px on the client, causing a style height mismatch. moment().locale() produces localized dates on the server but English on the client during hydration (locale files load async). initialData gated on router.isReady was true on server but false on client's first render, emptying the articles list. Fixed by: deferring virtualized rendering to post-mount, gating moment locale formatting on mounted, removing router.isReady from initialData condition. Removed stale test.fail() annotation that was causing the now-passing tests to fail.

2. signup-redirect birthday: #birthday changed from a native date input to a Popover+Calendar button. Replaced .fill() with calendar interaction (open popover, select year/month via dropdowns, click day button).

3. project-flow signin: next dev compiles routes on demand; fill() fires before hydration completes so react-hook-form never sees the values and the submit button stays disabled. Added waitForHydration helper (waits for __reactFiber on the input) plus toBeEnabled guard before clicking submit.

Validation: 24/24 e2e emulator tests pass, 230/230 unit tests pass, lint and prettier clean.