### PR TITLE
refactor: parallelize data fetches and dedupe scroll listeners

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import dynamic from 'next/dynamic'
 import Banner from '../components/Banner'
 import MyPageViewLogger from './Analytics'
+import { useScrollDirection } from '../lib/useScrollDirection'
 
 const NavBar = dynamic(() => import('./NavBar'), {
   ssr: false,
@@ -16,12 +17,13 @@ const Footer = dynamic(() => import('./Footer'), {
 const DEFAULT_NAV_HEIGHT = 76
 
 export default function Layout({ children }) {
-  const [visibleNav, setVisibleNav] = useState(true)
   const [visibleBanner, setVisibleBanner] = useState(true)
   const navWrapRef = useRef(null)
   const [navHeight, setNavHeight] = useState(
     DEFAULT_NAV_HEIGHT
   )
+  const scrollDirection = useScrollDirection()
+  const visibleNav = scrollDirection !== 'down'
 
   useEffect(() => {
     const node = navWrapRef.current
@@ -37,36 +39,8 @@ export default function Layout({ children }) {
     return () => observer.disconnect()
   }, [])
   useEffect(() => {
-    let previousY = document.documentElement.scrollTop
-
-    function handleScroll() {
-      let currentY = document.documentElement.scrollTop
-
-      if (currentY <= 350) {
-        setVisibleNav(true)
-        previousY = currentY
-      } else {
-        if (currentY - previousY >= 200) {
-          setVisibleNav(false)
-          previousY = currentY
-        }
-        if (previousY - currentY >= 200) {
-          setVisibleNav(true)
-          previousY = currentY
-        }
-      }
-    }
-
-    document.addEventListener('scroll', handleScroll, {
-      passive: true,
-    })
-
     if (sessionStorage.getItem('visibleBanner')) {
       setVisibleBanner(false)
-    }
-
-    return () => {
-      document.removeEventListener('scroll', handleScroll)
     }
   }, [])
 

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useSigninCheck } from '../context/AuthContext'
 import { auth } from '../lib/firebase'
+import { useScrollDirection } from '../lib/useScrollDirection'
 import { useContext, useState, useEffect } from 'react'
 import { AppContext } from '../context/context'
 import { signOut } from '@firebase/auth'
@@ -114,31 +115,12 @@ export default function NavBar() {
       i18n.addResourceBundle(router.locale, 'common')
   }, [router, i18n])
 
+  const scrollDirection = useScrollDirection()
   useEffect(() => {
-    let previousY = document.documentElement.scrollTop
-    function handleScroll() {
-      let currentY = document.documentElement.scrollTop
-
-      if (currentY <= 350) {
-        previousY = currentY
-      } else {
-        if (currentY - previousY >= 200) {
-          setShowMobileNav(false)
-          previousY = currentY
-        }
-        if (previousY - currentY >= 200) {
-          previousY = currentY
-        }
-      }
+    if (scrollDirection === 'down') {
+      setShowMobileNav(false)
     }
-    document.addEventListener('scroll', handleScroll, {
-      passive: true,
-    })
-
-    return () => {
-      document.removeEventListener('scroll', handleScroll)
-    }
-  }, [])
+  }, [scrollDirection])
 
   return (
     <nav suppressHydrationWarning={true}>

--- a/lib/useScrollDirection.js
+++ b/lib/useScrollDirection.js
@@ -1,0 +1,68 @@
+import { useSyncExternalStore } from 'react'
+
+// One scroll listener shared across every component that needs
+// scroll direction, instead of each mounting its own. Direction
+// only changes when the user crosses a distance threshold, so
+// subscribers re-render a few times per scroll gesture, not
+// per animation frame.
+const SCROLL_THRESHOLD = 200
+const TOP_OFFSET = 350
+
+let direction = 'at-top'
+let previousY = 0
+const listeners = new Set()
+
+function handleScroll() {
+  const currentY = document.documentElement.scrollTop
+  let next = direction
+
+  if (currentY <= TOP_OFFSET) {
+    next = 'at-top'
+  } else if (currentY - previousY >= SCROLL_THRESHOLD) {
+    next = 'down'
+  } else if (previousY - currentY >= SCROLL_THRESHOLD) {
+    next = 'up'
+  }
+
+  previousY = currentY
+
+  if (next !== direction) {
+    direction = next
+    listeners.forEach((l) => l())
+  }
+}
+
+function subscribe(callback) {
+  if (typeof document === 'undefined') return () => {}
+  listeners.add(callback)
+  if (listeners.size === 1) {
+    previousY = document.documentElement.scrollTop
+    direction =
+      previousY <= TOP_OFFSET ? 'at-top' : direction
+    document.addEventListener('scroll', handleScroll, {
+      passive: true,
+    })
+  }
+  return () => {
+    listeners.delete(callback)
+    if (listeners.size === 0) {
+      document.removeEventListener('scroll', handleScroll)
+    }
+  }
+}
+
+function getSnapshot() {
+  return direction
+}
+
+function getServerSnapshot() {
+  return 'at-top'
+}
+
+export function useScrollDirection() {
+  return useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot
+  )
+}

--- a/pages/about.js
+++ b/pages/about.js
@@ -180,9 +180,20 @@ export default function About() {
   ])
 
   useEffect(() => {
-    // Randomize the order of the members
+    // Randomize the order of the members via Fisher-Yates
+    // (sort-based shuffles are biased and non-uniform)
     let randomized_members = [...members]
-    randomized_members.sort(() => Math.random() - 0.5)
+    for (
+      let i = randomized_members.length - 1;
+      i > 0;
+      i--
+    ) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[randomized_members[i], randomized_members[j]] = [
+        randomized_members[j],
+        randomized_members[i],
+      ]
+    }
     setMembers(randomized_members)
   }, [])
 

--- a/pages/article/[slug].js
+++ b/pages/article/[slug].js
@@ -378,41 +378,37 @@ function Article({ article, recommendations }) {
 }
 
 export async function getStaticPaths() {
-  let paths = []
   const apiEndpoint =
     'https://sciteens.cdn.prismic.io/api/v2'
   const client = Prismic.client(apiEndpoint)
   const res = await client.query(
     Prismic.Predicates.at('document.type', 'blog')
   )
-  for (let i = 1; i <= res.total_pages; i++) {
-    const articles = await client.query(
-      Prismic.Predicates.at('document.type', 'blog'),
-      { pageSize: 20, page: i }
+  const pages = await Promise.all(
+    Array.from({ length: res.total_pages }, (_, i) =>
+      client.query(
+        Prismic.Predicates.at('document.type', 'blog'),
+        { pageSize: 20, page: i + 1 }
+      )
     )
-    for (let article of articles.results) {
-      paths.push({
-        params: { slug: article.uid },
-      })
-    }
-  }
-  return { paths: paths, fallback: false }
+  )
+  const paths = pages.flatMap((page) =>
+    page.results.map((article) => ({
+      params: { slug: article.uid },
+    }))
+  )
+  return { paths, fallback: false }
 }
 
 export async function getStaticProps({ params, locale }) {
-  // Fetch data from external API
-  const translations = await serverSideTranslations(
-    locale,
-    ['common']
-  )
   try {
     const apiEndpoint =
       'https://sciteens.cdn.prismic.io/api/v2'
     const client = Prismic.client(apiEndpoint)
-    const article = await client.getByUID(
-      'blog',
-      params?.slug
-    )
+    const [translations, article] = await Promise.all([
+      serverSideTranslations(locale, ['common']),
+      client.getByUID('blog', params?.slug),
+    ])
     const recommendationsQuery = await client.query([
       Prismic.Predicates.at('document.type', 'blog'),
       Prismic.Predicates.any('document.tags', article.tags),

--- a/pages/course/[slug].js
+++ b/pages/course/[slug].js
@@ -182,42 +182,37 @@ function Course({ course }) {
 }
 
 export async function getStaticPaths() {
-  let paths = []
   const apiEndpoint =
     'https://sciteens.cdn.prismic.io/api/v2'
   const client = Prismic.client(apiEndpoint)
   const res = await client.query(
     Prismic.Predicates.at('document.type', 'course')
   )
-  for (let i = 1; i <= res.total_pages; i++) {
-    const courses = await client.query(
-      Prismic.Predicates.at('document.type', 'course'),
-      { pageSize: 20, page: i }
+  const pages = await Promise.all(
+    Array.from({ length: res.total_pages }, (_, i) =>
+      client.query(
+        Prismic.Predicates.at('document.type', 'course'),
+        { pageSize: 20, page: i + 1 }
+      )
     )
-    for (let course of courses.results) {
-      paths.push({
-        params: { slug: course.uid },
-      })
-    }
-  }
-  return { paths: paths, fallback: false }
+  )
+  const paths = pages.flatMap((page) =>
+    page.results.map((course) => ({
+      params: { slug: course.uid },
+    }))
+  )
+  return { paths, fallback: false }
 }
 
 export async function getStaticProps({ params, locale }) {
-  // Fetch data from external API
-  const translations = await serverSideTranslations(
-    locale,
-    ['common']
-  )
-
   try {
     const apiEndpoint =
       'https://sciteens.cdn.prismic.io/api/v2'
     const client = Prismic.client(apiEndpoint)
-    const course = await client.getByUID(
-      'course',
-      params?.slug
-    )
+    const [translations, course] = await Promise.all([
+      serverSideTranslations(locale, ['common']),
+      client.getByUID('course', params?.slug),
+    ])
     return {
       props: { course, ...translations },
     }

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -454,7 +454,7 @@ function Projects({ cached_projects }) {
 
 export async function getStaticProps({ locale }) {
   let projects = []
-  const translations = await serverSideTranslations(
+  const translationsPromise = serverSideTranslations(
     locale,
     ['common']
   )
@@ -472,7 +472,10 @@ export async function getStaticProps({ locale }) {
     orderBy('date', 'desc'),
     limit(10)
   )
-  const projectsRef = await getDocs(projectsQuery)
+  const [translations, projectsRef] = await Promise.all([
+    translationsPromise,
+    getDocs(projectsQuery),
+  ])
   projectsRef.forEach((p) => {
     projects.push(
       normalizeProject({


### PR DESCRIPTION
Apply Vercel react-best-practices findings:

- Parallelize independent awaits in getStaticProps/getStaticPaths for article, course, and projects pages (async-parallel)
- Extract shared useScrollDirection hook using useSyncExternalStore, replacing duplicate scroll listeners in Layout.js and NavBar.js (client-event-listeners)
- Replace biased sort-based member shuffle in about.js with Fisher-Yates