### PR TITLE
feat: codify design philosophy and unify shadcn usage across pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,36 @@ args; without them `pnpm dev` errors at runtime, not install.
   Strings in `public/locales/{en,es,fr,hi}/common.json`. No hardcoded English
   user-facing copy.
 
+## Design philosophy
+
+SciTeens follows a **Minimalist / Swiss-style** design system:
+flat surfaces, borders as the primary visual separator, and
+restrained shadows (`shadow-sm`, never large soft-UI shadows).
+Color comes from the brand green palette
+(`sciteensGreen`, `sciteensLightGreen`, `backgroundGreen` in
+`styles/globals.css`); everything else is neutral grayscale via
+shadcn tokens.
+
+- **Prefer shadcn primitives** (`components/ui/*`) over hand-rolled
+  equivalents. If a `Card`, `Button`, `Badge`, `Input`, `Skeleton`,
+  or `Separator` fits, use it instead of recreating the styles with
+  raw `<div>`/`<a>` + ad-hoc Tailwind. Only deviate when a
+  component genuinely needs behavior the primitive doesn't provide.
+- **Card pattern**: `Card` + `CardContent` with `border-border/60`
+  and `shadow-sm`, matching `ProjectCard`. Listing items (projects,
+  articles, courses) should share this shape.
+- **Mobile gutter consistency**: the nav bar sits at `mx-4`; page
+  content on mobile must use `px-4` to align with it. Differing
+  widths (e.g. `w-11/12`, `w-5/6`, `lg:w-1/2`) should only apply
+  at `md:` and above, never on the base/mobile layer.
+- **Consistent radius**: use the theme radius scale
+  (`rounded-xl` for cards, `rounded-lg` for nested media). Do not
+  mix `rounded-sm`, `rounded-md`, or bare corners on content
+  surfaces.
+- **Loading states**: use `Skeleton` (`components/ui/skeleton.jsx`)
+  for shimmer placeholders, not ad-hoc `bg-muted animate-pulse`
+  divs.
+
 ## Architecture
 
 - One Next.js app: `pages/`, `components/`, `context/` + `lib/` (client

--- a/pages/about.js
+++ b/pages/about.js
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
 import PageHeading from '@/components/PageHeading'
+import { Card, CardContent } from '@/components/ui/card'
 
 export default function About() {
   const { t } = useTranslation('common')
@@ -250,10 +251,55 @@ export default function About() {
               <div className="mb-8 inline-grid h-full w-full grid-cols-2 place-items-center lg:grid-cols-3">
                 {currentMembers.map((member) => {
                   return (
-                    <div
+                    <Card
                       key={member.name}
-                      className="member border-border/60 bg-card relative mb-6 h-[90%] w-11/12 scale-0 rounded-xl border p-4 shadow-sm transition-all duration-500 md:p-8"
+                      className="member relative mb-6 h-[90%] w-full scale-0 transition-all duration-500"
                     >
+                      <CardContent className="p-4 md:p-8">
+                        <Image
+                          src={`/assets/headshots/${member.image}`}
+                          alt={member.name}
+                          width={112}
+                          height={112}
+                          className="m-auto mb-4 h-20 w-20 rounded-full object-cover shadow-sm lg:h-28 lg:w-28"
+                        />
+                        <p className="mb-2 text-center text-base font-semibold md:text-2xl">
+                          {member.name}
+                        </p>
+                        <p
+                          className={`text-muted-foreground hidden text-center md:block
+                                      ${
+                                        member.name ===
+                                          'Angelica Castillejos' ||
+                                        member.name ===
+                                          'Tasman Rosenfeld'
+                                          ? 'text-sm'
+                                          : 'text-base'
+                                      }`}
+                        >
+                          {member.about}
+                        </p>
+                      </CardContent>
+                    </Card>
+                  )
+                })}
+              </div>
+            </>
+          )}
+
+          <h2 className="mb-6 text-center text-2xl font-bold md:text-3xl">
+            {t('about.previous_members')}
+          </h2>
+          <div className="mb-8 inline-grid h-full w-full grid-cols-2 place-items-center lg:grid-cols-3">
+            {members
+              .filter((m) => m.current == false)
+              .map((member) => {
+                return (
+                  <Card
+                    key={member.name}
+                    className="member relative mb-6 h-[90%] w-full scale-0 transition-all duration-500"
+                  >
+                    <CardContent className="p-4 md:p-8">
                       <Image
                         src={`/assets/headshots/${member.image}`}
                         alt={member.name}
@@ -277,49 +323,8 @@ export default function About() {
                       >
                         {member.about}
                       </p>
-                    </div>
-                  )
-                })}
-              </div>
-            </>
-          )}
-
-          <h2 className="mb-6 text-center text-2xl font-bold md:text-3xl">
-            {t('about.previous_members')}
-          </h2>
-          <div className="mb-8 inline-grid h-full w-full grid-cols-2 place-items-center lg:grid-cols-3">
-            {members
-              .filter((m) => m.current == false)
-              .map((member) => {
-                return (
-                  <div
-                    key={member.name}
-                    className="member border-border/60 bg-card relative mb-6 h-[90%] w-11/12 scale-0 rounded-xl border p-4 shadow-sm transition-all duration-500 md:p-8"
-                  >
-                    <Image
-                      src={`/assets/headshots/${member.image}`}
-                      alt={member.name}
-                      width={112}
-                      height={112}
-                      className="m-auto mb-4 h-20 w-20 rounded-full object-cover shadow-sm lg:h-28 lg:w-28"
-                    />
-                    <p className="mb-2 text-center text-base font-semibold md:text-2xl">
-                      {member.name}
-                    </p>
-                    <p
-                      className={`text-muted-foreground hidden text-center md:block
-                                    ${
-                                      member.name ===
-                                        'Angelica Castillejos' ||
-                                      member.name ===
-                                        'Tasman Rosenfeld'
-                                        ? 'text-sm'
-                                        : 'text-base'
-                                    }`}
-                    >
-                      {member.about}
-                    </p>
-                  </div>
+                    </CardContent>
+                  </Card>
                 )
               })}
           </div>

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 
-import Link from 'next/link'
 import SocialMeta from '@/components/SocialMeta'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
@@ -18,6 +17,9 @@ import { getTranslatedFieldsDict } from '../context/helpers'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { useWindowVirtualizer } from '@tanstack/react-virtual'
 import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import {
   Select,
@@ -288,42 +290,50 @@ function Articles({ cached_articles }) {
 
     return (
       <div key={article.id} className="w-full pt-6 md:pt-8">
-        <Link
-          href={`/article/${article.uid}`}
-          className="animate-in bg-card text-card-foreground ring-border/60 fade-in slide-in-from-right-8 z-50 flex cursor-pointer flex-row items-center rounded-xl p-4 shadow-sm ring-1 transition duration-300 hover:-translate-y-0.5 hover:shadow-md"
-        >
-          <div className="relative h-full max-w-[100px] md:max-w-[200px]">
-            <Image
-              alt={RichText.asText(article.data.title)}
-              className="shrink-0 rounded-lg object-cover"
-              loader={imageLoader}
-              src={article.data.image.url}
-              width={256}
-              height={256}
-            />
-          </div>
-          <div className="ml-4 w-3/4 lg:w-11/12">
-            <div className="mb-3 flex flex-row items-center">
-              {author_image}
-              <p className="ml-3">{article.data.author}</p>
+        <Card className="animate-in border-border/60 fade-in slide-in-from-right-8 relative isolate overflow-hidden transition duration-300 hover:-translate-y-0.5 hover:shadow-md">
+          <a
+            href={`/article/${article.uid}`}
+            aria-label={RichText.asText(article.data.title)}
+            className="focus-visible:ring-3 focus-visible:ring-ring/50 absolute inset-0 z-10 rounded-xl"
+          />
+          <CardContent className="flex items-center">
+            <div className="bg-muted relative h-24 w-24 shrink-0 overflow-hidden rounded-lg md:h-40 md:w-40">
+              <Image
+                alt={RichText.asText(article.data.title)}
+                fill
+                sizes="(min-width: 768px) 160px, 96px"
+                className="object-cover"
+                loader={imageLoader}
+                src={article.data.image.url}
+              />
             </div>
-            <h3 className="line-clamp-2 mb-2 text-base font-semibold md:text-xl lg:text-2xl">
-              {RichText.asText(article.data.title)}
-            </h3>
-            <p className="line-clamp-none md:line-clamp-2 mb-2 hidden text-sm md:flex lg:text-base">
-              {article.data.description}
-            </p>
-            <p className="flex text-xs">
-              {(mounted
-                ? moment(article.data.date)
-                    .locale(router?.locale || 'en')
-                    .format('ll')
-                : moment(article.data.date).format('ll')) +
-                ' · ' +
-                readingTime(article.data.text)}
-            </p>
-          </div>
-        </Link>
+            <div className="ml-4 min-w-0 flex-1">
+              <div className="mb-3 flex flex-row items-center">
+                {author_image}
+                <p className="ml-3">
+                  {article.data.author}
+                </p>
+              </div>
+              <h3 className="line-clamp-2 mb-2 text-base font-semibold md:text-xl lg:text-2xl">
+                {RichText.asText(article.data.title)}
+              </h3>
+              <p className="line-clamp-none md:line-clamp-2 mb-2 hidden text-sm md:flex lg:text-base">
+                {article.data.description}
+              </p>
+              <p className="flex text-xs">
+                {(mounted
+                  ? moment(article.data.date)
+                      .locale(router?.locale || 'en')
+                      .format('ll')
+                  : moment(article.data.date).format(
+                      'll'
+                    )) +
+                  ' · ' +
+                  readingTime(article.data.text)}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
       </div>
     )
   }
@@ -374,10 +384,10 @@ function Articles({ cached_articles }) {
     .fill(1)
     .map((index) => {
       return (
-        <div
+        <Skeleton
           key={index}
-          className="bg-muted z-50 mt-4 h-16 rounded-xl p-4 shadow-sm"
-        ></div>
+          className="mt-4 h-16 rounded-xl"
+        />
       )
     })
 
@@ -395,7 +405,7 @@ function Articles({ cached_articles }) {
         path="/articles"
       />
       <div className="text-foreground mx-auto mb-24 mt-8 flex min-h-screen flex-row overflow-x-hidden md:overflow-visible lg:mx-16 xl:mx-32">
-        <div className="mx-auto w-11/12 md:w-[85%] lg:mx-0 lg:w-[60%]">
+        <div className="w-full px-4 md:mx-auto md:w-[85%] md:px-0 lg:mx-0 lg:w-[60%]">
           <PageHeading className="ml-4 py-4 text-left">
             {t('articles.articles')} 📰
           </PageHeading>
@@ -501,7 +511,7 @@ function Articles({ cached_articles }) {
               </Button>
             </form>
 
-            <hr className="bg-border my-8" />
+            <Separator className="my-8" />
 
             <h2 className="text-muted-foreground mb-2 text-xl">
               {t('courses.topics')}

--- a/pages/course/[slug].js
+++ b/pages/course/[slug].js
@@ -11,6 +11,9 @@ import { useRouter } from 'next/router'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
 import { createCropImageLoader } from '../../lib/prismicImageLoader'
+import { Card, CardContent } from '@/components/ui/card'
+import { Separator } from '@/components/ui/separator'
+import { Button } from '@/components/ui/button'
 
 function Course({ course }) {
   const [files, setFiles] = useState([])
@@ -66,13 +69,20 @@ function Course({ course }) {
               {RichText.asText(slice.primary.title)}
             </td>
             <td className="p-2">
-              <a
-                href={slice.primary.lesson_link.url}
-                target="_blank"
-                rel="noreferrer"
+              <Button
+                variant="link"
+                size="sm"
+                render={
+                  <a
+                    href={slice.primary.lesson_link.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label="View"
+                  />
+                }
               >
                 View
-              </a>
+              </Button>
             </td>
           </tr>
         )
@@ -124,7 +134,7 @@ function Course({ course }) {
           <h1>{RichText.asText(course.data.name)}</h1>
           {courseDateDisplay}
           <i>{RichText.asText(course.data.description)}</i>
-          <div className="mt-2 border-b-2"></div>
+          <Separator className="mt-2" />
           {/* <div className="flex items-center">
                                     {author_image}
                                     <p className="font-semibold ml-4">
@@ -150,18 +160,26 @@ function Course({ course }) {
           </div>
         </div>
       </article>
-      <div className="mx-auto w-full max-w-prose">
+      <div className="mx-auto w-full max-w-prose px-4">
         <h2 className="mb-2 text-lg font-semibold">
           {t('course.lessons')}
         </h2>
-        <table className="mb-4 w-full table-auto rounded-sm shadow-sm">
-          <tr className="border-border bg-muted rounded-t-md border-b text-center">
-            <th className="p-2">{t('course.date')}</th>
-            <th className="p-2">{t('course.lesson')}</th>
-            <th className="p-2">{t('course.notebook')}</th>
-          </tr>
-          {lessonComponent}
-        </table>
+        <Card className="mb-4 overflow-hidden">
+          <CardContent className="p-0">
+            <table className="w-full table-auto">
+              <tr className="border-border bg-muted border-b text-center">
+                <th className="p-2">{t('course.date')}</th>
+                <th className="p-2">
+                  {t('course.lesson')}
+                </th>
+                <th className="p-2">
+                  {t('course.notebook')}
+                </th>
+              </tr>
+              {lessonComponent}
+            </table>
+          </CardContent>
+        </Card>
         {files?.length > 0 && (
           <>
             <h2 className="mb-2 text-lg font-semibold">

--- a/pages/courses.js
+++ b/pages/courses.js
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react'
 
-import Link from 'next/link'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
 import SocialMeta from '@/components/SocialMeta'
@@ -13,6 +12,8 @@ import moment from 'moment'
 
 import { getTranslatedFieldsDict } from '../context/helpers'
 import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import PageHeading from '@/components/PageHeading'
 
@@ -131,30 +132,37 @@ function Courses({ cached_courses }) {
     }
 
     return (
-      <Link
+      <Card
         key={course.uid}
-        href={`/course/${course.uid}`}
-        className="animate-in bg-card text-card-foreground ring-border/60 fade-in slide-in-from-right-8 z-50 mt-6 flex cursor-pointer items-center rounded-xl p-4 shadow-sm ring-1 transition duration-300 hover:-translate-y-0.5 hover:shadow-md md:mt-8"
+        className="animate-in border-border/60 fade-in slide-in-from-right-8 relative isolate mt-6 overflow-hidden transition duration-300 hover:-translate-y-0.5 hover:shadow-md md:mt-8"
       >
-        <div className="relative h-full max-w-[100px] md:max-w-[200px]">
-          <Image
-            className="shrink-0 rounded-lg object-cover"
-            loader={imageLoader}
-            src={course.data.image_main.url}
-            width={256}
-            height={256}
-          />
-        </div>
-        <div className="ml-4 w-3/4 lg:w-11/12">
-          <h3 className="line-clamp-2 mb-2 text-base font-semibold md:text-xl lg:text-2xl">
-            {RichText.asText(course.data.name)}
-          </h3>
-          <p className="line-clamp-none md:line-clamp-2 lg:line-clamp-3 mb-2 hidden md:block">
-            {RichText.asText(course.data.description)}
-          </p>
-          {dateDisplay}
-        </div>
-      </Link>
+        <a
+          href={`/course/${course.uid}`}
+          aria-label={RichText.asText(course.data.name)}
+          className="focus-visible:ring-3 focus-visible:ring-ring/50 absolute inset-0 z-10 rounded-xl"
+        />
+        <CardContent className="flex items-center">
+          <div className="bg-muted relative h-24 w-24 shrink-0 overflow-hidden rounded-lg md:h-40 md:w-40">
+            <Image
+              alt={RichText.asText(course.data.name)}
+              fill
+              sizes="(min-width: 768px) 160px, 96px"
+              className="object-cover"
+              loader={imageLoader}
+              src={course.data.image_main.url}
+            />
+          </div>
+          <div className="ml-4 min-w-0 flex-1">
+            <h3 className="line-clamp-2 mb-2 text-base font-semibold md:text-xl lg:text-2xl">
+              {RichText.asText(course.data.name)}
+            </h3>
+            <p className="line-clamp-none md:line-clamp-2 lg:line-clamp-3 mb-2 hidden md:block">
+              {RichText.asText(course.data.description)}
+            </p>
+            {dateDisplay}
+          </div>
+        </CardContent>
+      </Card>
     )
   })
   return (
@@ -171,7 +179,7 @@ function Courses({ cached_courses }) {
         path="/courses"
       />
       <div className="text-foreground mx-auto mb-24 mt-8 flex min-h-screen flex-row overflow-x-hidden md:overflow-visible lg:mx-16 xl:mx-32">
-        <div className="mx-auto w-11/12 md:w-[85%] lg:mx-0 lg:w-[60%]">
+        <div className="w-full px-4 md:mx-auto md:w-[85%] md:px-0 lg:mx-0 lg:w-[60%]">
           <PageHeading className="ml-4 py-4 text-left">
             {t('courses.courses')} 📖
           </PageHeading>
@@ -217,7 +225,7 @@ function Courses({ cached_courses }) {
               </Button>
             </form>
 
-            <hr className="bg-border my-8" />
+            <Separator className="my-8" />
 
             <h2 className="text-muted-foreground mb-2 text-xl">
               {t('courses.topics')}

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -4,6 +4,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
 import SocialMeta from '@/components/SocialMeta'
 import PageHeading from '@/components/PageHeading'
+import { Button } from '@/components/ui/button'
 
 export default function Donate() {
   const { t } = useTranslation('common')
@@ -21,20 +22,26 @@ export default function Donate() {
             {t('donate.annual_donation_appeal')}
           </PageHeading>
           <div className="mb-8 mt-4 flex w-full flex-row">
-            <a
-              href="https://www.paypal.com/donate?hosted_button_id=7B8QACYV83ACA"
-              target="_blank"
-              className="bg-sciteensLightGreen-regular hover:bg-sciteensLightGreen-dark mr-2 rounded-lg p-2 text-white shadow-md"
-              rel="noreferrer"
+            <Button
+              render={
+                <a
+                  href="https://www.paypal.com/donate?hosted_button_id=7B8QACYV83ACA"
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={t('donate.donate_now')}
+                />
+              }
+              className="mr-2"
             >
               {t('donate.donate_now')}
-            </a>
-            <Link
-              href="/about"
-              className="text-muted-foreground ml-2 p-2 hover:underline"
+            </Button>
+            <Button
+              variant="ghost"
+              render={<Link href="/about" />}
+              className="ml-2"
             >
               {t('donate.read_our_mission')}
-            </Link>
+            </Button>
           </div>
           <p>{t('donate.dear_supporter')}</p>
           <p className="my-2">

--- a/pages/profile/[slug]/index.js
+++ b/pages/profile/[slug]/index.js
@@ -125,7 +125,7 @@ function Project({ profile }) {
         eyebrow="Profile"
         path={router.asPath}
       />
-      <div className="text-foreground mx-auto mt-12 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
+      <div className="text-foreground mx-auto mt-12 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
         <Card className="animate-in border-border/60 fade-in slide-in-from-bottom-4 overflow-hidden duration-300">
           <CardContent className="flex flex-col gap-6 p-6 sm:flex-row sm:items-center md:p-8">
             <div className="ring-background size-20 md:size-28 shrink-0 self-start rounded-full shadow-sm ring-4 sm:self-center">
@@ -194,12 +194,12 @@ function Project({ profile }) {
         </Card>
       </div>
 
-      <div className="mx-auto mt-12 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
+      <div className="mx-auto mt-12 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
         <Separator />
       </div>
 
       {/* Projects */}
-      <div className="mx-auto mb-4 mt-8 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
+      <div className="mx-auto mb-4 mt-8 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
         <h2 className="mb-2 text-lg font-semibold md:text-2xl">
           {t('index_profile.projects')}
         </h2>
@@ -217,12 +217,12 @@ function Project({ profile }) {
         )}
       </div>
 
-      <div className="mx-auto mt-12 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
+      <div className="mx-auto mt-12 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
         <Separator />
       </div>
 
       {/* Files */}
-      <div className="mx-auto mb-4 mt-8 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
+      <div className="mx-auto mb-4 mt-8 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
         {(filesStatus === 'loading' ||
           fileRecords.length > 0) && (
           <h2 className="mb-2 text-lg font-semibold md:text-2xl">

--- a/pages/project/[id]/index.js
+++ b/pages/project/[id]/index.js
@@ -130,7 +130,7 @@ function Project({ query, initialProject }) {
         }
         path={router.asPath}
       />
-      <div className="text-foreground mx-auto mt-12 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
+      <div className="text-foreground mx-auto mt-12 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
         <Card className="border-border/60 overflow-hidden">
           <CardContent className="flex flex-col gap-4 p-6 md:p-8">
             <div className="flex flex-row items-start justify-between gap-4">
@@ -215,12 +215,12 @@ function Project({ query, initialProject }) {
         </Card>
       </div>
 
-      <div className="mx-auto mt-12 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
+      <div className="mx-auto mt-12 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
         <Separator />
       </div>
 
       {/* Abstract */}
-      <div className="mx-auto mb-4 mt-8 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
+      <div className="mx-auto mb-4 mt-8 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
         <h2 className="mb-2 text-lg font-semibold md:text-2xl">
           {t('project_create_edit.summary')}
         </h2>
@@ -235,10 +235,10 @@ function Project({ query, initialProject }) {
 
       {hasTopicsOrLinks && (
         <>
-          <div className="mx-auto mt-12 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
+          <div className="mx-auto mt-12 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
             <Separator />
           </div>
-          <div className="mx-auto mb-4 mt-8 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
+          <div className="mx-auto mb-4 mt-8 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
             {project.fields?.length > 0 && (
               <>
                 <h2 className="mb-2 text-lg font-semibold md:text-2xl">
@@ -296,12 +296,12 @@ function Project({ query, initialProject }) {
         </>
       )}
 
-      <div className="mx-auto mt-12 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
+      <div className="mx-auto mt-12 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
         <Separator />
       </div>
 
       {/* Files */}
-      <div className="mx-auto mb-4 mt-8 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
+      <div className="mx-auto mb-4 mt-8 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
         {filesStatus === 'success' &&
           fileRecords.length > 0 && (
             <h2 className="mb-2 text-lg font-semibold md:text-2xl">
@@ -322,12 +322,12 @@ function Project({ query, initialProject }) {
         )}
       </div>
 
-      <div className="mx-auto mt-12 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
+      <div className="mx-auto mt-12 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
         <Separator />
       </div>
 
       {/* Discussion */}
-      <div className="mx-auto mb-4 mt-8 w-5/6 px-4 md:w-2/3 lg:w-1/2 lg:px-0">
+      <div className="mx-auto mb-4 mt-8 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
         <Discussion type="projects" item_id={query.id} />
       </div>
     </>

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -38,6 +38,8 @@ import {
   formatProjectDate,
 } from '../lib/projects'
 import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Input } from '@/components/ui/input'
 
 const PROJECTS_PAGE_SIZE = 10
@@ -326,10 +328,10 @@ function Projects({ cached_projects }) {
     .fill(1)
     .map((index) => {
       return (
-        <div
+        <Skeleton
           key={index}
-          className="bg-muted z-50 mt-4 h-16 rounded-xl p-4 shadow-sm"
-        ></div>
+          className="mt-4 h-16 rounded-xl"
+        />
       )
     })
 
@@ -347,21 +349,22 @@ function Projects({ cached_projects }) {
         path="/projects"
       />
       <div className="text-foreground mx-auto mb-24 mt-8 flex min-h-screen flex-row overflow-x-hidden md:overflow-visible lg:mx-16 xl:mx-32">
-        <div className="mx-auto w-11/12 md:w-[85%] lg:mx-0 lg:w-[60%]">
+        <div className="w-full px-4 md:mx-auto md:w-[85%] md:px-0 lg:mx-0 lg:w-[60%]">
           <div className="flex flex-row justify-between">
             <PageHeading className="ml-0 py-4 text-left md:ml-4">
               {t('projects.projects')} 🔬
             </PageHeading>
-            <Link
-              href="/project/create"
-              className="border-sciteensLightGreen-regular text-sciteensLightGreen-regular hover:border-sciteensLightGreen-dark hover:text-sciteensLightGreen-dark my-auto inline-flex items-center rounded-lg border-2 px-3 py-1.5 no-underline shadow-sm transition md:px-5 md:text-lg"
+            <Button
+              variant="outline"
+              render={<Link href="/project/create" />}
+              className="my-auto md:px-5 md:text-lg"
               aria-label="Create Project"
             >
               <span className="hidden md:inline">
                 Create Project
               </span>
               <PlusCircle className="h-6 w-6 md:hidden" />
-            </Link>
+            </Button>
           </div>
           {loading && projects.length === 0
             ? loadingComponent
@@ -417,7 +420,7 @@ function Projects({ cached_projects }) {
               </Button>
             </form>
 
-            <hr className="bg-border my-8" />
+            <Separator className="my-8" />
 
             <h2 className="text-muted-foreground mb-2 text-xl">
               {t('projects.topics')}


### PR DESCRIPTION
Add Minimalist/Swiss-style design philosophy section to AGENTS.md documenting border-first separation, restrained shadow-sm, brand green palette, and shadcn primitives as the default.

Fix mobile width inconsistency: all page content containers now use px-4 on mobile to align with the nav bar mx-4 gutter. Listing pages (w-11/12) and detail pages (w-5/6) both now use w-full px-4 at base, with larger widths only at md: and above.

Convert hand-rolled card patterns to shadcn Card/CardContent across courses listing, articles listing, about member cards, and course detail lessons table. Replace ad-hoc loading divs with Skeleton, hr separators with Separator, and raw styled links with Button.