### PR TITLE
fix: prevent mobile scroll halt on articles/projects infinite scroll

### DIFF
--- a/pages/articles.js
+++ b/pages/articles.js
@@ -22,6 +22,13 @@ import FilterAside from '@/components/search/FilterAside'
 import TopicsList from '@/components/search/TopicsList'
 
 const ARTICLES_PAGE_SIZE = 10
+// Matches the virtualized row's estimateSize/measured height closely
+// enough that the "fetching next page" skeleton and the real card it's
+// replaced by are roughly the same height. A generic short skeleton
+// here would make the page grow by ~250px the instant the page
+// resolves, which is exactly the kind of layout shift that kills
+// momentum scrolling on mobile.
+const ARTICLE_CARD_ESTIMATE = 340
 
 async function fetchArticlesPage({
   search,
@@ -168,7 +175,12 @@ function Articles({ cached_articles }) {
   const ref = useRef(null)
   const isBottomVisible = useIntersectionObserver(
     ref,
-    { threshold: 0 },
+    // Fires well before the sentinel is actually on screen so the next
+    // page has time to fetch and render while the user is still
+    // scrolling through existing content, instead of appending new
+    // rows right as they hit the bottom edge (which is what made
+    // scrolling feel like it "halted" on mobile).
+    { threshold: 0, rootMargin: '600px 0px' },
     false
   )
 
@@ -325,7 +337,7 @@ function Articles({ cached_articles }) {
 
   const articleVirtualizer = useWindowVirtualizer({
     count: articles.length,
-    estimateSize: () => 340,
+    estimateSize: () => ARTICLE_CARD_ESTIMATE,
     overscan: 5,
   })
 
@@ -376,6 +388,19 @@ function Articles({ cached_articles }) {
       )
     })
 
+  // Sized to ARTICLE_CARD_ESTIMATE (not the short generic skeleton
+  // above) so the page's height barely changes when these are swapped
+  // for the real cards that follow.
+  const nextPageLoadingComponent = new Array(2)
+    .fill(1)
+    .map((index) => (
+      <Skeleton
+        key={index}
+        className="mt-4 w-full rounded-xl"
+        style={{ height: ARTICLE_CARD_ESTIMATE }}
+      />
+    ))
+
   const filterPanel = (
     <TopicsList
       topicsLabel={t('articles.topics')}
@@ -424,7 +449,7 @@ function Articles({ cached_articles }) {
 
             {loading ? loadingComponent : articlesComponent}
             {articlesQuery.isFetchingNextPage &&
-              loadingComponent.slice(0, 2)}
+              nextPageLoadingComponent}
             {articles.length === 0 && !loading && (
               <div className="mx-auto mt-20 text-center">
                 <i className="text-xl font-semibold">

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -63,6 +63,13 @@ import FilterAside from '@/components/search/FilterAside'
 import TopicsList from '@/components/search/TopicsList'
 
 const PROJECTS_PAGE_SIZE = 10
+// Matches the virtualized row's estimateSize/measured height closely
+// enough that the "fetching next page" skeleton and the real card it's
+// replaced by are roughly the same height. A generic short skeleton
+// here would make the page grow the instant the fetch resolves, which
+// is exactly the kind of layout shift that kills momentum scrolling
+// on mobile.
+const PROJECT_CARD_ESTIMATE = 320
 
 function mapProjectSnapshot(snapshot) {
   const projects = []
@@ -434,7 +441,12 @@ function Projects({ cached_projects }) {
   const ref = useRef(null)
   const isBottomVisible = useIntersectionObserver(
     ref,
-    { threshold: 0 },
+    // Fires well before the sentinel is actually on screen so the next
+    // page has time to fetch and render while the user is still
+    // scrolling through existing content, instead of appending new
+    // rows right as they hit the bottom edge (which is what made
+    // scrolling feel like it "halted" on mobile).
+    { threshold: 0, rootMargin: '600px 0px' },
     false
   )
 
@@ -509,7 +521,7 @@ function Projects({ cached_projects }) {
 
   const projectVirtualizer = useWindowVirtualizer({
     count: projects.length,
-    estimateSize: () => 320,
+    estimateSize: () => PROJECT_CARD_ESTIMATE,
     overscan: 5,
   })
 
@@ -559,6 +571,19 @@ function Projects({ cached_projects }) {
         />
       )
     })
+
+  // Sized to PROJECT_CARD_ESTIMATE (not the short generic skeleton
+  // above) so the page's height barely changes when these are swapped
+  // for the real cards that follow.
+  const nextPageLoadingComponent = new Array(2)
+    .fill(1)
+    .map((index) => (
+      <Skeleton
+        key={index}
+        className="mt-6 w-full rounded-xl md:mt-8"
+        style={{ height: PROJECT_CARD_ESTIMATE }}
+      />
+    ))
 
   const filterPanelProps = {
     t,
@@ -675,7 +700,7 @@ function Projects({ cached_projects }) {
                 : projectsComponent}
             </div>
             {projectsQuery.isFetchingNextPage &&
-              loadingComponent.slice(0, 2)}
+              nextPageLoadingComponent}
             {!loading &&
               !projectsQuery.isError &&
               projects.length === 0 &&


### PR DESCRIPTION
Prefetch the next page via a 600px rootMargin instead of waiting for the sentinel to hit the viewport edge, and size the in-flight-fetch skeleton to match the virtualizer's card estimate instead of the short generic skeleton. Both closed a large layout-shift window that landed mid-scroll on mobile and stalled momentum scrolling.