### PR TITLE
fix: stop mobile momentum scroll from canceling on articles/projects …

### DIFF
--- a/context/helpers.js
+++ b/context/helpers.js
@@ -5,7 +5,16 @@ import {
   GoogleAuthProvider,
   getAdditionalUserInfo,
 } from '@firebase/auth'
-import { useState, useRef, useEffect } from 'react'
+import {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+} from 'react'
+import {
+  useWindowVirtualizer,
+  measureElement as virtualMeasureElement,
+} from '@tanstack/react-virtual'
 import moment from 'moment'
 
 export async function createUniqueSlug(
@@ -205,6 +214,50 @@ export function useIntersectionObserver(
   }, [element, options])
 
   return isIntersecting
+}
+
+// A fixed estimateSize forces the virtualizer to keep correcting the
+// scroll offset every time a newly-mounted row's real measured height
+// turns out to differ from the guess — and these listing cards render
+// at very different heights depending on viewport (smaller thumbnail,
+// no description paragraph below the `md` breakpoint), so any single
+// hardcoded number is wrong for most rows on one side of that
+// breakpoint. Each of those corrections is a programmatic scroll
+// write, which is exactly what cuts a momentum-scroll fling short on
+// mobile. Instead of hand-tuning per-breakpoint constants (which goes
+// stale the moment the card markup changes), estimate every
+// not-yet-measured row from the most recently measured one — after
+// the first row or two mounts, the estimate is self-correcting and
+// stays within a few pixels of reality at any viewport size.
+export function useAdaptiveWindowVirtualizer({
+  count,
+  initialEstimate,
+  overscan = 5,
+}) {
+  const lastMeasuredSize = useRef(initialEstimate)
+  const measureElement = useCallback(
+    (element, entry, instance) => {
+      const size = virtualMeasureElement(
+        element,
+        entry,
+        instance
+      )
+      lastMeasuredSize.current = size
+      return size
+    },
+    []
+  )
+  const estimateSize = useCallback(
+    () => lastMeasuredSize.current,
+    []
+  )
+
+  return useWindowVirtualizer({
+    count,
+    estimateSize,
+    measureElement,
+    overscan,
+  })
 }
 
 // A File's `name` is fully attacker-controlled (a client-side upload can

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -5,7 +5,10 @@ import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
-import { useIntersectionObserver } from '../context/helpers'
+import {
+  useIntersectionObserver,
+  useAdaptiveWindowVirtualizer,
+} from '../context/helpers'
 import PageHeading from '@/components/PageHeading'
 
 var Prismic = require('@prismicio/client')
@@ -14,7 +17,6 @@ import { RichText } from 'prismic-reactjs'
 import moment from 'moment'
 import { getTranslatedFieldsDict } from '../context/helpers'
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { useWindowVirtualizer } from '@tanstack/react-virtual'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import SearchToolbar from '@/components/search/SearchToolbar'
@@ -22,13 +24,12 @@ import FilterAside from '@/components/search/FilterAside'
 import TopicsList from '@/components/search/TopicsList'
 
 const ARTICLES_PAGE_SIZE = 10
-// Matches the virtualized row's estimateSize/measured height closely
-// enough that the "fetching next page" skeleton and the real card it's
-// replaced by are roughly the same height. A generic short skeleton
-// here would make the page grow by ~250px the instant the page
-// resolves, which is exactly the kind of layout shift that kills
-// momentum scrolling on mobile.
-const ARTICLE_CARD_ESTIMATE = 340
+// Rough guess used only before the first row has been measured (and
+// for the "fetching next page" skeleton, so it doesn't visibly jump
+// once the real card replaces it) — the virtualizer self-corrects
+// from real measured heights after that. See
+// useAdaptiveWindowVirtualizer in context/helpers.js.
+const ARTICLE_CARD_ESTIMATE = 220
 
 async function fetchArticlesPage({
   search,
@@ -335,9 +336,9 @@ function Articles({ cached_articles }) {
     )
   }
 
-  const articleVirtualizer = useWindowVirtualizer({
+  const articleVirtualizer = useAdaptiveWindowVirtualizer({
     count: articles.length,
-    estimateSize: () => ARTICLE_CARD_ESTIMATE,
+    initialEstimate: ARTICLE_CARD_ESTIMATE,
     overscan: 5,
   })
 

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -11,8 +11,11 @@ import SocialMeta from '@/components/SocialMeta'
 import { useRouter } from 'next/router'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
-import { useIntersectionObserver } from '../context/helpers'
-import { getTranslatedFieldsDict } from '../context/helpers'
+import {
+  useIntersectionObserver,
+  useAdaptiveWindowVirtualizer,
+  getTranslatedFieldsDict,
+} from '../context/helpers'
 import PageHeading from '@/components/PageHeading'
 
 import { db as firestore } from '../lib/firebase'
@@ -37,7 +40,6 @@ import {
   useInfiniteQuery,
   useQuery,
 } from '@tanstack/react-query'
-import { useWindowVirtualizer } from '@tanstack/react-virtual'
 
 import { PlusCircle } from 'lucide-react'
 import ProjectCard from '../components/ProjectCard'
@@ -63,13 +65,12 @@ import FilterAside from '@/components/search/FilterAside'
 import TopicsList from '@/components/search/TopicsList'
 
 const PROJECTS_PAGE_SIZE = 10
-// Matches the virtualized row's estimateSize/measured height closely
-// enough that the "fetching next page" skeleton and the real card it's
-// replaced by are roughly the same height. A generic short skeleton
-// here would make the page grow the instant the fetch resolves, which
-// is exactly the kind of layout shift that kills momentum scrolling
-// on mobile.
-const PROJECT_CARD_ESTIMATE = 320
+// Rough guess used only before the first row has been measured (and
+// for the "fetching next page" skeleton, so it doesn't visibly jump
+// once the real card replaces it) — the virtualizer self-corrects
+// from real measured heights after that. See
+// useAdaptiveWindowVirtualizer in context/helpers.js.
+const PROJECT_CARD_ESTIMATE = 220
 
 function mapProjectSnapshot(snapshot) {
   const projects = []
@@ -519,9 +520,9 @@ function Projects({ cached_projects }) {
     router.push({ pathname: '/projects' })
   }
 
-  const projectVirtualizer = useWindowVirtualizer({
+  const projectVirtualizer = useAdaptiveWindowVirtualizer({
     count: projects.length,
-    estimateSize: () => PROJECT_CARD_ESTIMATE,
+    initialEstimate: PROJECT_CARD_ESTIMATE,
     overscan: 5,
   })
 


### PR DESCRIPTION
…lists

The virtualized article/project card lists fed useWindowVirtualizer a single hardcoded estimateSize tuned for desktop. Real mobile card height is roughly half that (smaller thumbnail, no description paragraph), so every newly-mounted row forced a large scroll-offset correction as soon as it was measured. On iOS WebKit that correction is deferred until the touch/scroll settles, then flushed as one lump write, which is what canceled momentum scrolling mid-fling.

Replace the fixed estimate with useAdaptiveWindowVirtualizer (context/helpers.js): it seeds estimateSize from the most recently *measured* row instead of a hardcoded constant, so the guess stays within a few pixels of reality at any viewport width without per-breakpoint magic numbers that go stale the next time the card markup changes.