### PR TITLE
refactor: remove dead Algolia program sync block

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -517,26 +517,6 @@ exports.newProgram = functions.firestore
         fields: data.fields,
         hits: data.hits,
       })
-      .then(() => {
-        // Add the program to algolia
-        let data_minified = {
-          name: data.name,
-          loc: data.loc,
-          img: data.img,
-          about: data.about,
-          start: data.start,
-          end: data.end,
-          app: data.app,
-          coord: data.coord,
-          _geoloc: data.coord,
-          geo: data.geo,
-          slug: data.slug,
-          grade_h: data.grade_h,
-          grade_l: data.grade_l,
-          fields: data.fields,
-          hits: data.hits,
-        }
-      })
   })
 
 /*


### PR DESCRIPTION
The .then() in newProgram built a data_minified object for Algolia but never sent it anywhere. Leftover from the Meilisearch migration; no behavior change.