### PR TITLE
feat: replace virtualized lists with infinite scroll on articles and …

### DIFF
--- a/components/InfiniteScrollTrigger.js
+++ b/components/InfiniteScrollTrigger.js
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react'
+import { Button } from '@/components/ui/button'
+import LoadingSpinner from '@/components/LoadingSpinner'
+
+export default function InfiniteScrollTrigger({
+  hasNextPage,
+  isLoading,
+  onLoadMore,
+  label,
+}) {
+  const triggerRef = useRef(null)
+
+  useEffect(() => {
+    const trigger = triggerRef.current
+    if (
+      !trigger ||
+      !hasNextPage ||
+      isLoading ||
+      typeof IntersectionObserver === 'undefined'
+    ) {
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) onLoadMore()
+      },
+      { rootMargin: '600px 0px' }
+    )
+    observer.observe(trigger)
+
+    return () => observer.disconnect()
+  }, [hasNextPage, isLoading, onLoadMore])
+
+  if (!hasNextPage) return null
+
+  return (
+    <div
+      ref={triggerRef}
+      className="mt-6 flex justify-center md:mt-8"
+    >
+      <Button
+        type="button"
+        variant="outline"
+        className="bg-card shadow-sm"
+        disabled={isLoading}
+        onClick={onLoadMore}
+      >
+        {label}
+        {isLoading && <LoadingSpinner className="ml-2" />}
+      </Button>
+    </div>
+  )
+}

--- a/components/InfiniteScrollTrigger.test.js
+++ b/components/InfiniteScrollTrigger.test.js
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react'
+import InfiniteScrollTrigger from './InfiniteScrollTrigger'
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}))
+
+class MockIntersectionObserver {
+  constructor(callback, options) {
+    this.callback = callback
+    this.options = options
+    this.observe = vi.fn()
+    this.disconnect = vi.fn()
+    MockIntersectionObserver.instances.push(this)
+  }
+}
+MockIntersectionObserver.instances = []
+
+afterEach(() => {
+  cleanup()
+  MockIntersectionObserver.instances = []
+  vi.unstubAllGlobals()
+})
+
+describe('InfiniteScrollTrigger', () => {
+  it('loads the next page before the trigger reaches the viewport', () => {
+    vi.stubGlobal(
+      'IntersectionObserver',
+      MockIntersectionObserver
+    )
+    const onLoadMore = vi.fn()
+
+    render(
+      <InfiniteScrollTrigger
+        hasNextPage
+        isLoading={false}
+        onLoadMore={onLoadMore}
+        label="Load more"
+      />
+    )
+
+    const observer = MockIntersectionObserver.instances[0]
+    expect(observer.options).toEqual({
+      rootMargin: '600px 0px',
+    })
+    expect(observer.observe).toHaveBeenCalledOnce()
+
+    act(() => {
+      observer.callback([{ isIntersecting: true }])
+    })
+    expect(onLoadMore).toHaveBeenCalledOnce()
+  })
+
+  it('keeps a manual load button when IntersectionObserver is unavailable', () => {
+    vi.stubGlobal('IntersectionObserver', undefined)
+    const onLoadMore = vi.fn()
+
+    render(
+      <InfiniteScrollTrigger
+        hasNextPage
+        isLoading={false}
+        onLoadMore={onLoadMore}
+        label="Load more"
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Load more' })
+    )
+    expect(onLoadMore).toHaveBeenCalledOnce()
+  })
+
+  it('disconnects the observer and disables loading twice while a request is active', () => {
+    vi.stubGlobal(
+      'IntersectionObserver',
+      MockIntersectionObserver
+    )
+    const onLoadMore = vi.fn()
+    const { rerender } = render(
+      <InfiniteScrollTrigger
+        hasNextPage
+        isLoading={false}
+        onLoadMore={onLoadMore}
+        label="Load more"
+      />
+    )
+    const observer = MockIntersectionObserver.instances[0]
+
+    rerender(
+      <InfiniteScrollTrigger
+        hasNextPage
+        isLoading
+        onLoadMore={onLoadMore}
+        label="Load more"
+      />
+    )
+
+    expect(observer.disconnect).toHaveBeenCalledOnce()
+    expect(
+      screen.getByRole('button', { name: /Load more/ })
+    ).toBeDisabled()
+  })
+
+  it('renders no trigger after the final page', () => {
+    vi.stubGlobal(
+      'IntersectionObserver',
+      MockIntersectionObserver
+    )
+
+    render(
+      <InfiniteScrollTrigger
+        hasNextPage={false}
+        isLoading={false}
+        onLoadMore={vi.fn()}
+        label="Load more"
+      />
+    )
+
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(MockIntersectionObserver.instances).toHaveLength(
+      0
+    )
+  })
+})

--- a/components/ProjectCard.js
+++ b/components/ProjectCard.js
@@ -60,7 +60,7 @@ export default function ProjectCard({
     Boolean(normalizedProject?.project_photo) && !photoError
 
   return (
-    <Card className="animate-in border-border/60 fade-in slide-in-from-right-8 relative isolate overflow-hidden transition duration-300 hover:-translate-y-0.5 hover:shadow-md">
+    <Card className="border-border/60 relative isolate overflow-hidden transition duration-300 hover:-translate-y-0.5 hover:shadow-md">
       <a
         href={`/project/${normalizedProject.id}`}
         aria-label={normalizedProject.title}

--- a/context/helpers.js
+++ b/context/helpers.js
@@ -5,11 +5,6 @@ import {
   GoogleAuthProvider,
   getAdditionalUserInfo,
 } from '@firebase/auth'
-import { useRef, useCallback } from 'react'
-import {
-  useWindowVirtualizer,
-  measureElement as virtualMeasureElement,
-} from '@tanstack/react-virtual'
 import moment from 'moment'
 
 export async function createUniqueSlug(
@@ -161,54 +156,6 @@ export function validatePassword(password, t) {
   } else {
     return ''
   }
-}
-
-// A fixed estimateSize forces the virtualizer to keep correcting the
-// scroll offset every time a newly-mounted row's real measured height
-// turns out to differ from the guess — and these listing cards render
-// at very different heights depending on viewport (smaller thumbnail,
-// no description paragraph below the `md` breakpoint), so any single
-// hardcoded number is wrong for most rows on one side of that
-// breakpoint. @tanstack/react-virtual >=3.14 defers these
-// scroll-offset corrections on iOS WebKit until a touch/momentum
-// gesture settles (writing scrollTop mid-gesture is what used to cut
-// scrolling short there), but a wildly wrong estimate still means a
-// big correction lands the moment it flushes, and it costs an extra
-// re-render either way. Instead of hand-tuning per-breakpoint
-// constants (which goes stale the moment the card markup changes),
-// estimate every not-yet-measured row from the most recently measured
-// one — after the first row or two mounts, the estimate is
-// self-correcting and stays within a few pixels of reality at any
-// viewport size.
-export function useAdaptiveWindowVirtualizer({
-  count,
-  initialEstimate,
-  overscan = 5,
-}) {
-  const lastMeasuredSize = useRef(initialEstimate)
-  const measureElement = useCallback(
-    (element, entry, instance) => {
-      const size = virtualMeasureElement(
-        element,
-        entry,
-        instance
-      )
-      lastMeasuredSize.current = size
-      return size
-    },
-    []
-  )
-  const estimateSize = useCallback(
-    () => lastMeasuredSize.current,
-    []
-  )
-
-  return useWindowVirtualizer({
-    count,
-    estimateSize,
-    measureElement,
-    overscan,
-  })
 }
 
 // A File's `name` is fully attacker-controlled (a client-side upload can

--- a/e2e/projects-filter.spec.js
+++ b/e2e/projects-filter.spec.js
@@ -4,20 +4,16 @@
 // once in e2e/global-setup.js to avoid racing project-flow.spec.js.
 const { test, expect } = require('@playwright/test')
 
-// The list is virtualized and paginated behind a "Load more" button —
-// click it until the target shows up or there's nothing left to load.
-async function loadUntilVisible(
+// The list loads the next page as its trigger approaches the viewport.
+// Scroll in bounded steps until the target appears or pagination ends.
+async function scrollUntilVisible(
   page,
   locator,
   { maxAttempts = 20 } = {}
 ) {
-  const loadMore = page.getByRole('button', {
-    name: /Load more/i,
-  })
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     if (await locator.isVisible()) return
-    if (!(await loadMore.isVisible())) break
-    await loadMore.click()
+    await page.mouse.wheel(0, 900)
     await page.waitForTimeout(250)
   }
   await expect(locator).toBeVisible({ timeout: 5_000 })
@@ -42,8 +38,8 @@ test.describe('projects field filtering', () => {
       name: 'E2E Modern Biology Project',
     })
 
-    await loadUntilVisible(page, legacyLink)
-    await loadUntilVisible(page, modernLink)
+    await scrollUntilVisible(page, legacyLink)
+    await scrollUntilVisible(page, modernLink)
 
     // Both cards show the same translated badge regardless of storage
     // casing (getFieldLabel's case-insensitive fallback).

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@squoosh/lib": "^0.5.3",
     "@tailwindcss/typography": "^0.5.15",
     "@tanstack/react-query": "^5.101.2",
-    "@tanstack/react-virtual": "^3.14.5",
     "@vercel/og": "^0.11.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -5,10 +5,8 @@ import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
-import { useAdaptiveWindowVirtualizer } from '../context/helpers'
+import InfiniteScrollTrigger from '@/components/InfiniteScrollTrigger'
 import PageHeading from '@/components/PageHeading'
-import { Button } from '@/components/ui/button'
-import LoadingSpinner from '@/components/LoadingSpinner'
 
 var Prismic = require('@prismicio/client')
 import { RichText } from 'prismic-reactjs'
@@ -23,12 +21,6 @@ import FilterAside from '@/components/search/FilterAside'
 import TopicsList from '@/components/search/TopicsList'
 
 const ARTICLES_PAGE_SIZE = 10
-// Rough guess used only before the first row has been measured (and
-// for the "fetching next page" skeleton, so it doesn't visibly jump
-// once the real card replaces it) — the virtualizer self-corrects
-// from real measured heights after that. See
-// useAdaptiveWindowVirtualizer in context/helpers.js.
-const ARTICLE_CARD_ESTIMATE = 220
 
 async function fetchArticlesPage({
   search,
@@ -86,10 +78,6 @@ function Articles({ cached_articles }) {
   const [search, setSearch] = useState('')
   const [field, setField] = useState('')
   const [filtersOpen, setFiltersOpen] = useState(false)
-  // useWindowVirtualizer computes getTotalSize() from window
-  // dimensions, which are absent during SSR — rendering it on the
-  // server produces height:0px vs the client's real height, a
-  // hydration mismatch. Defer virtualized rendering to after mount.
   const [mounted, setMounted] = useState(false)
   useEffect(() => setMounted(true), [])
 
@@ -260,7 +248,7 @@ function Articles({ cached_articles }) {
 
     return (
       <div key={article.id} className="w-full pt-6 md:pt-8">
-        <Card className="animate-in border-border/60 fade-in slide-in-from-right-8 relative isolate overflow-hidden transition duration-300 hover:-translate-y-0.5 hover:shadow-md">
+        <Card className="border-border/60 relative isolate overflow-hidden transition duration-300 hover:-translate-y-0.5 hover:shadow-md">
           <a
             href={`/article/${article.uid}`}
             aria-label={RichText.asText(article.data.title)}
@@ -308,42 +296,8 @@ function Articles({ cached_articles }) {
     )
   }
 
-  const articleVirtualizer = useAdaptiveWindowVirtualizer({
-    count: articles.length,
-    initialEstimate: ARTICLE_CARD_ESTIMATE,
-    overscan: 5,
-  })
-
-  const articlesComponent = mounted ? (
-    <div
-      className="relative w-full"
-      style={{
-        height: `${articleVirtualizer.getTotalSize()}px`,
-      }}
-    >
-      {articleVirtualizer
-        .getVirtualItems()
-        .map((virtualRow) => {
-          const article = articles[virtualRow.index]
-          if (!article) return null
-
-          return (
-            <div
-              key={article.id}
-              ref={articleVirtualizer.measureElement}
-              data-index={virtualRow.index}
-              className="absolute left-0 top-0 w-full"
-              style={{
-                transform: `translateY(${virtualRow.start}px)`,
-              }}
-            >
-              {renderArticleCard(article)}
-            </div>
-          )
-        })}
-    </div>
-  ) : (
-    <div className="relative w-full">
+  const articlesComponent = (
+    <div className="w-full">
       {articles.map((article) =>
         renderArticleCard(article)
       )}
@@ -361,16 +315,12 @@ function Articles({ cached_articles }) {
       )
     })
 
-  // Sized to ARTICLE_CARD_ESTIMATE (not the short generic skeleton
-  // above) so the page's height barely changes when these are swapped
-  // for the real cards that follow.
   const nextPageLoadingComponent = new Array(2)
     .fill(1)
     .map((index) => (
       <Skeleton
         key={index}
-        className="mt-4 w-full rounded-xl"
-        style={{ height: ARTICLE_CARD_ESTIMATE }}
+        className="mt-6 h-32 w-full rounded-xl md:mt-8 md:h-48"
       />
     ))
 
@@ -432,22 +382,12 @@ function Articles({ cached_articles }) {
                 </i>
               </div>
             )}
-            {hasNextPage && (
-              <div className="mt-6 flex justify-center md:mt-8">
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="bg-card shadow-sm"
-                  disabled={isFetchingNextPage}
-                  onClick={() => fetchNextPage()}
-                >
-                  {t('articles.load_more')}
-                  {isFetchingNextPage && (
-                    <LoadingSpinner className="ml-2" />
-                  )}
-                </Button>
-              </div>
-            )}
+            <InfiniteScrollTrigger
+              hasNextPage={hasNextPage}
+              isLoading={isFetchingNextPage}
+              onLoadMore={fetchNextPage}
+              label={t('articles.load_more')}
+            />
           </div>
 
           <FilterAside>{filterPanel}</FilterAside>

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -5,10 +5,7 @@ import SocialMeta from '@/components/SocialMeta'
 import { useRouter } from 'next/router'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
-import {
-  useAdaptiveWindowVirtualizer,
-  getTranslatedFieldsDict,
-} from '../context/helpers'
+import { getTranslatedFieldsDict } from '../context/helpers'
 import PageHeading from '@/components/PageHeading'
 
 import { db as firestore } from '../lib/firebase'
@@ -36,7 +33,7 @@ import {
 
 import { PlusCircle } from 'lucide-react'
 import ProjectCard from '../components/ProjectCard'
-import LoadingSpinner from '@/components/LoadingSpinner'
+import InfiniteScrollTrigger from '@/components/InfiniteScrollTrigger'
 import {
   normalizeProject,
   formatProjectDate,
@@ -59,12 +56,6 @@ import FilterAside from '@/components/search/FilterAside'
 import TopicsList from '@/components/search/TopicsList'
 
 const PROJECTS_PAGE_SIZE = 10
-// Rough guess used only before the first row has been measured (and
-// for the "fetching next page" skeleton, so it doesn't visibly jump
-// once the real card replaces it) — the virtualizer self-corrects
-// from real measured heights after that. See
-// useAdaptiveWindowVirtualizer in context/helpers.js.
-const PROJECT_CARD_ESTIMATE = 220
 
 function mapProjectSnapshot(snapshot) {
   const projects = []
@@ -340,7 +331,6 @@ function Projects({ cached_projects }) {
 
   const initialData = useMemo(() => {
     if (
-      !router.isReady ||
       searchParam ||
       fieldParam ||
       dateFromParam ||
@@ -365,7 +355,6 @@ function Projects({ cached_projects }) {
       pageParams: [null],
     }
   }, [
-    router.isReady,
     searchParam,
     fieldParam,
     dateFromParam,
@@ -487,45 +476,22 @@ function Projects({ cached_projects }) {
     router.push({ pathname: '/projects' })
   }
 
-  const projectVirtualizer = useAdaptiveWindowVirtualizer({
-    count: projects.length,
-    initialEstimate: PROJECT_CARD_ESTIMATE,
-    overscan: 5,
-  })
-
   const projectsComponent = (
-    <div
-      className="relative w-full"
-      style={{
-        height: `${projectVirtualizer.getTotalSize()}px`,
-      }}
-    >
-      {projectVirtualizer
-        .getVirtualItems()
-        .map((virtualRow) => {
-          const project = projects[virtualRow.index]
-          if (!project) return null
-
-          return (
-            <div
-              key={project.id}
-              ref={projectVirtualizer.measureElement}
-              data-index={virtualRow.index}
-              className="absolute left-0 top-0 w-full pt-6 md:pt-8"
-              style={{
-                transform: `translateY(${virtualRow.start}px)`,
-              }}
-            >
-              <ProjectCard
-                project={project}
-                date={formatProjectDate(
-                  project.date,
-                  router?.locale
-                )}
-              />
-            </div>
-          )
-        })}
+    <div className="w-full">
+      {projects.map((project) => (
+        <div
+          key={project.id}
+          className="w-full pt-6 md:pt-8"
+        >
+          <ProjectCard
+            project={project}
+            date={formatProjectDate(
+              project.date,
+              router?.locale
+            )}
+          />
+        </div>
+      ))}
     </div>
   )
 
@@ -540,16 +506,12 @@ function Projects({ cached_projects }) {
       )
     })
 
-  // Sized to PROJECT_CARD_ESTIMATE (not the short generic skeleton
-  // above) so the page's height barely changes when these are swapped
-  // for the real cards that follow.
   const nextPageLoadingComponent = new Array(2)
     .fill(1)
     .map((index) => (
       <Skeleton
         key={index}
-        className="mt-6 w-full rounded-xl md:mt-8"
-        style={{ height: PROJECT_CARD_ESTIMATE }}
+        className="mt-6 h-32 w-full rounded-xl md:mt-8 md:h-48"
       />
     ))
 
@@ -681,22 +643,12 @@ function Projects({ cached_projects }) {
                   </i>
                 </div>
               )}
-            {hasNextPage && (
-              <div className="mt-6 flex justify-center md:mt-8">
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="bg-card shadow-sm"
-                  disabled={isFetchingNextPage}
-                  onClick={() => fetchNextPage()}
-                >
-                  {t('projects.load_more')}
-                  {isFetchingNextPage && (
-                    <LoadingSpinner className="ml-2" />
-                  )}
-                </Button>
-              </div>
-            )}
+            <InfiniteScrollTrigger
+              hasNextPage={hasNextPage}
+              isLoading={isFetchingNextPage}
+              onLoadMore={fetchNextPage}
+              label={t('projects.load_more')}
+            />
           </div>
 
           <FilterAside>

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -292,6 +292,8 @@ function Projects({ cached_projects }) {
     to: '',
   })
   const [filtersOpen, setFiltersOpen] = useState(false)
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => setMounted(true), [])
 
   const searchParam = router.query?.search || ''
   const fieldParam =
@@ -472,7 +474,6 @@ function Projects({ cached_projects }) {
     setField('')
     setSort('')
     setDateRange({ from: '', to: '' })
-    setFiltersOpen(false)
     router.push({ pathname: '/projects' })
   }
 
@@ -487,7 +488,7 @@ function Projects({ cached_projects }) {
             project={project}
             date={formatProjectDate(
               project.date,
-              router?.locale
+              mounted ? router?.locale : undefined
             )}
           />
         </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.101.2
         version: 5.101.2(react@18.3.1)
-      '@tanstack/react-virtual':
-        specifier: ^3.14.5
-        version: 3.14.5(react-dom@18.3.1)(react@18.3.1)
       '@vercel/og':
         specifier: ^0.11.1
         version: 0.11.1
@@ -3311,21 +3308,6 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@tanstack/react-virtual@3.14.5(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    dependencies:
-      '@tanstack/virtual-core': 3.17.3
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    dev: false
-
-  /@tanstack/virtual-core@3.17.3:
-    resolution: {integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==}
-    dev: false
-
   /@testing-library/dom@10.4.1:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -4056,6 +4038,7 @@ packages:
   /agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
+    requiresBuild: true
     dependencies:
       debug: 4.4.3
     transitivePeerDependencies:
@@ -7499,6 +7482,7 @@ packages:
   /https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+    requiresBuild: true
     dependencies:
       agent-base: 6.0.2
       debug: 4.4.3


### PR DESCRIPTION
…projects

Root cause: @tanstack/react-virtual dynamic measurement + row remounting + entrance animations interrupted iOS WebKit momentum scrolling. The virtualizer's internal scroll corrections (even deferred) still triggered re-renders and layout shifts that killed scroll momentum.

Solution: remove virtualization entirely; render full lists in document flow with a shared InfiniteScrollTrigger component that auto-loads the next page 600px before the sentinel and falls back to an accessible 'Load more' button.

Changes:
- Remove @tanstack/react-virtual and useAdaptiveWindowVirtualizer
- Add components/InfiniteScrollTrigger.js (+ unit tests)
- Replace virtualized rendering with simple .map() in pages/articles.js and pages/projects.js
- Fix /projects hydration by removing router.isReady gate from initialData
- Update e2e scroll helper for scroll-driven pagination
- Update pnpm-lock.yaml

Validation: 291 unit tests pass, lint passes, production build passes, mobile viewport smoke test confirms 10→20 cards appended without first-card unmount or page errors