### PR TITLE
feat: resize/recompress uploaded images server-side to WebP

### DIFF
--- a/context/helpers.js
+++ b/context/helpers.js
@@ -273,6 +273,25 @@ export function getSafeUploadName(file) {
   return `${generateUploadId()}.${ext}`
 }
 
+// Storage path for a freshly uploaded profile/project file. A
+// display photo goes under its own `photo/` subpath (mirroring the
+// existing `thumbnails/` subpath convention) so the fileUpload Cloud
+// Function (functions/index.js + functions/lib/imageOptimize.js) can
+// tell it apart from a regular gallery file by path alone and resize
+// it down to the small dimensions it's actually ever displayed at,
+// without racing the Firestore `isPhoto` write that happens after
+// this upload completes.
+export function getUploadStoragePath(
+  ownerPrefix,
+  ownerId,
+  safeName,
+  isPhoto
+) {
+  return isPhoto
+    ? `${ownerPrefix}/${ownerId}/photo/${safeName}`
+    : `${ownerPrefix}/${ownerId}/${safeName}`
+}
+
 // Builds the Firestore record written alongside every Storage upload,
 // at `projects/{id}/files/{fileId}` or `profiles/{uid}/files/{fileId}`
 // — `fileId` is always the object's own basename (getSafeUploadName's

--- a/context/helpers.test.js
+++ b/context/helpers.test.js
@@ -20,6 +20,7 @@ import {
   getProjectFieldOptions,
   getSafeUploadName,
   getTranslatedFieldsDict,
+  getUploadStoragePath,
   isAllowedLink,
   isLegacyUnsupportedFile,
   resolveRefPath,
@@ -486,5 +487,40 @@ describe('buildFileRecord', () => {
     expect(Number.isNaN(Date.parse(record.createdAt))).toBe(
       false
     )
+  })
+})
+
+describe('getUploadStoragePath', () => {
+  it('puts a display photo under its own photo/ subpath', () => {
+    expect(
+      getUploadStoragePath(
+        'profiles',
+        'uid1',
+        'abc123.jpg',
+        true
+      )
+    ).toBe('profiles/uid1/photo/abc123.jpg')
+  })
+
+  it('puts a non-photo file at the flat prefix', () => {
+    expect(
+      getUploadStoragePath(
+        'profiles',
+        'uid1',
+        'abc123.jpg',
+        false
+      )
+    ).toBe('profiles/uid1/abc123.jpg')
+  })
+
+  it('works for the project owner prefix too', () => {
+    expect(
+      getUploadStoragePath(
+        'projects',
+        'proj1',
+        'abc123.jpg',
+        true
+      )
+    ).toBe('projects/proj1/photo/abc123.jpg')
   })
 })

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,3 +1,4 @@
+const crypto = require('node:crypto')
 // Firebase
 const functions = require('firebase-functions/v1')
 const {
@@ -771,9 +772,73 @@ exports.scheduledProgramEmailer = functions
     entire file is deleted.
 */
 
+const sharp = require('sharp')
+const {
+  isResizeEligiblePath,
+  getResizeTarget,
+  WEBP_QUALITY,
+} = require('./lib/imageOptimize')
+
+// Resizes/recompresses an image object in place to WebP, per the
+// target dimensions from lib/imageOptimize.js. Overwrites the SAME
+// object path with `.save()` rather than deleting + re-uploading
+// under a new name, preserving (or minting, if absent) the object's
+// `firebaseStorageDownloadTokens` metadata — that's what keeps the
+// download URL the client already captured (it calls
+// `getDownloadURL()` right after `uploadBytes()`, before this trigger
+// has necessarily run) valid after the bytes underneath it change.
+// The `optimized: 'true'` custom-metadata flag it sets is what the
+// top of onFinalize below checks to avoid reprocessing its own
+// overwrite in an infinite trigger loop.
+async function optimizeImageObject(object) {
+  const bucket = admin.storage().bucket(object.bucket)
+  const file = bucket.file(object.name)
+
+  const [buffer] = await file.download()
+  const target = getResizeTarget(object.name)
+  const webpBuffer = await sharp(buffer)
+    .resize(target)
+    .webp({ quality: WEBP_QUALITY })
+    .toBuffer()
+
+  const [freshMetadata] = await file.getMetadata()
+  const existingTokens =
+    freshMetadata.metadata?.firebaseStorageDownloadTokens
+  const token = existingTokens
+    ? existingTokens.split(',')[0]
+    : crypto.randomUUID()
+
+  await file.save(webpBuffer, {
+    contentType: 'image/webp',
+    metadata: {
+      cacheControl: freshMetadata.cacheControl,
+      metadata: {
+        ...freshMetadata.metadata,
+        optimized: 'true',
+        firebaseStorageDownloadTokens: token,
+      },
+    },
+  })
+
+  console.log(
+    `Optimized ${object.name}: ${buffer.length}B -> ${webpBuffer.length}B`
+  )
+}
+
 exports.fileUpload = functions.storage
   .object()
   .onFinalize(async (object) => {
+    // Our own in-place optimizeImageObject() overwrite re-triggers
+    // this same function (a new object generation of the same path);
+    // it was already SafeSearch-checked and resized as the original
+    // upload, so just stop here instead of re-scanning, re-resizing,
+    // or looping forever.
+    if (object.metadata?.optimized === 'true') {
+      return console.log(
+        'Skipping already-optimized object ' + object.name
+      )
+    }
+
     const contentType = object.contentType
     if (!contentType) {
       return console.log('No content type')
@@ -859,6 +924,29 @@ exports.fileUpload = functions.storage
     console.log(
       'No offensive content found for ' + object.name
     )
+    // Resize/recompress eligible images in place (see
+    // lib/imageOptimize.js). profiles/{uid}/... and
+    // projects/{projectId}/... don't need makePublic() or a
+    // Firestore write here — the client already wrote the file
+    // record + display-photo pointer fields itself right after
+    // upload (see pages/profile/[slug]/edit.js,
+    // pages/project/create.js, pages/project/[id]/edit.js), keyed to
+    // the download-token URL optimizeImageObject() preserves above.
+    // A resize failure is logged, not thrown — the unoptimized
+    // original stays live rather than the upload silently vanishing.
+    if (isImage && isResizeEligiblePath(object.name)) {
+      try {
+        await optimizeImageObject(object)
+      } catch (err) {
+        console.error(
+          'Failed to optimize image ' +
+            object.name +
+            ': ' +
+            err
+        )
+      }
+      return
+    }
 
     // File passed moderation. Make it public and update the
     // corresponding Firestore record based on the upload path.

--- a/functions/lib/imageOptimize.js
+++ b/functions/lib/imageOptimize.js
@@ -1,0 +1,65 @@
+// Resize/recompress targets for uploaded images, applied by the
+// fileUpload trigger in functions/index.js. Mirrored in
+// scripts/lib/imageOptimize.js for the one-off backfill migration
+// (scripts/backfill-optimize-images.js) that re-processes images
+// uploaded before this existed — keep the two in sync by hand if
+// these numbers ever change.
+//
+// - Profile/project "display photo" (uploaded to a `.../photo/`
+//   subpath — see context/helpers.js#getUploadStoragePath): shown at
+//   most at 96px (components/ProfilePhoto.js) / 160px (ProjectCard,
+//   desktop). 400x400 covers up to ~4x pixel density at the largest
+//   on-site usage while staying tiny.
+// - Any other uploaded image (profile/project gallery file): shown up
+//   to 768px wide (project detail hero, FileGallery's lightbox
+//   `max-w-3xl`). 1600px longest edge covers ~2x retina at that size.
+const PHOTO_DIMENSION = 400
+const GENERAL_MAX_DIMENSION = 1600
+const WEBP_QUALITY = 82
+
+function isPhotoObjectPath(objectPath) {
+  return /\/photo\//.test(objectPath)
+}
+
+function isThumbnailObjectPath(objectPath) {
+  return /\/thumbnails\//.test(objectPath)
+}
+
+// profiles/{uid}/... or projects/{projectId}/... (flat, or the
+// /photo/ subpath above), excluding /thumbnails/ — the only prefixes
+// this trigger/migration ever resizes. courses/ (Prismic-managed) and
+// the legacy singular profilephoto//project/ prefixes are left
+// untouched, matching the fileUpload function's existing handling of
+// those as separate branches.
+function isResizeEligiblePath(objectPath) {
+  if (isThumbnailObjectPath(objectPath)) return false
+  return (
+    /^profiles\//.test(objectPath) ||
+    /^projects\//.test(objectPath)
+  )
+}
+
+function getResizeTarget(objectPath) {
+  return isPhotoObjectPath(objectPath)
+    ? {
+        width: PHOTO_DIMENSION,
+        height: PHOTO_DIMENSION,
+        fit: 'cover',
+      }
+    : {
+        width: GENERAL_MAX_DIMENSION,
+        height: GENERAL_MAX_DIMENSION,
+        fit: 'inside',
+        withoutEnlargement: true,
+      }
+}
+
+module.exports = {
+  PHOTO_DIMENSION,
+  GENERAL_MAX_DIMENSION,
+  WEBP_QUALITY,
+  isPhotoObjectPath,
+  isThumbnailObjectPath,
+  isResizeEligiblePath,
+  getResizeTarget,
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -18,6 +18,7 @@
     "firebase-admin": "^13.10.0",
     "firebase-functions": "^7.2.5",
     "node-mailjet": "^3.4.1",
+    "sharp": "^0.33.5",
     "slugify": "^1.6.9"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:unit": "vitest run context lib components tests/pages scripts",
     "test:watch": "vitest context lib components tests/pages scripts",
     "test:rules": "firebase emulators:exec --project demo-sciteens-test --only firestore,storage \"vitest run tests/rules --no-file-parallelism\"",
+    "backfill:images": "node scripts/backfill-optimize-images.js",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },
@@ -76,6 +77,7 @@
     "postcss": "^8.5.16",
     "prettier": "^2.8.8",
     "prettier-plugin-tailwindcss": "^0.1.13",
+    "sharp": "^0.33.5",
     "tailwindcss": "^4.3.2",
     "vitest": "^4.1.10"
   },

--- a/pages/profile/[slug]/edit.js
+++ b/pages/profile/[slug]/edit.js
@@ -65,6 +65,7 @@ import {
   ALLOWED_UPLOAD_MIME_TYPES,
   buildFileRecord,
   getSafeUploadName,
+  getUploadStoragePath,
   isAllowedLink,
   MAX_LINKS,
 } from '../../../context/helpers'
@@ -248,7 +249,12 @@ export default function UpdateProfilePage({
         }
         const fileRef = ref(
           storage,
-          `profiles/${user_profile.id}/${safeName}`
+          getUploadStoragePath(
+            'profiles',
+            user_profile.id,
+            safeName,
+            isPhoto
+          )
         )
         await uploadBytes(fileRef, f)
         const downloadURL = await getDownloadURL(fileRef)

--- a/pages/project/[id]/edit.js
+++ b/pages/project/[id]/edit.js
@@ -47,6 +47,7 @@ import {
   buildFileRecord,
   getProjectFieldOptions,
   getSafeUploadName,
+  getUploadStoragePath,
   isAllowedLink,
 } from '../../../context/helpers'
 import { generatePdfThumbnailBlob } from '../../../lib/pdfThumbnail'
@@ -331,7 +332,12 @@ export default function UpdateProject({ query }) {
         }
         const fileRef = ref(
           storage,
-          `projects/${query.id}/${safeName}`
+          getUploadStoragePath(
+            'projects',
+            query.id,
+            safeName,
+            isPhoto
+          )
         )
         await uploadBytes(fileRef, f)
         const downloadURL = await getDownloadURL(fileRef)

--- a/pages/project/create.js
+++ b/pages/project/create.js
@@ -38,6 +38,7 @@ import {
   buildFileRecord,
   getProjectFieldOptions,
   getSafeUploadName,
+  getUploadStoragePath,
   isAllowedLink,
 } from '../../context/helpers'
 import { generatePdfThumbnailBlob } from '../../lib/pdfThumbnail'
@@ -188,13 +189,18 @@ export default function CreateProject() {
           )
           continue
         }
+        const isPhoto = f.name == project_photo
         const fileRef = ref(
           storage,
-          `projects/${res.id}/${safeName}`
+          getUploadStoragePath(
+            'projects',
+            res.id,
+            safeName,
+            isPhoto
+          )
         )
         await uploadBytes(fileRef, f)
         const downloadURL = await getDownloadURL(fileRef)
-        const isPhoto = f.name == project_photo
 
         // Best-effort: a thumbnail-generation failure (corrupt/
         // encrypted/unrenderable PDF) must never block the upload

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 12.16.0
       image-minimizer-webpack-plugin:
         specifier: ^3.8.3
-        version: 3.8.3(@squoosh/lib@0.5.3)(webpack@5.108.3)
+        version: 3.8.3(@squoosh/lib@0.5.3)(sharp@0.33.5)(webpack@5.108.3)
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8
@@ -174,6 +174,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.1.13
         version: 0.1.13(prettier@2.8.8)
+      sharp:
+        specifier: ^0.33.5
+        version: 0.33.5
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -201,6 +204,9 @@ importers:
       node-mailjet:
         specifier: ^3.4.1
         version: 3.4.1
+      sharp:
+        specifier: ^0.33.5
+        version: 0.33.5
       slugify:
         specifier: ^1.6.9
         version: 1.6.9
@@ -1665,6 +1671,16 @@ packages:
     dev: false
     optional: true
 
+  /@img/sharp-darwin-arm64@0.33.5:
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
   /@img/sharp-darwin-arm64@0.34.5:
     resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -1674,6 +1690,16 @@ packages:
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
     dev: false
+    optional: true
+
+  /@img/sharp-darwin-x64@0.33.5:
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
     optional: true
 
   /@img/sharp-darwin-x64@0.34.5:
@@ -1687,12 +1713,26 @@ packages:
     dev: false
     optional: true
 
+  /@img/sharp-libvips-darwin-arm64@1.0.4:
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
   /@img/sharp-libvips-darwin-arm64@1.2.4:
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@img/sharp-libvips-darwin-x64@1.0.4:
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
     optional: true
 
   /@img/sharp-libvips-darwin-x64@1.2.4:
@@ -1703,12 +1743,26 @@ packages:
     dev: false
     optional: true
 
+  /@img/sharp-libvips-linux-arm64@1.0.4:
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@img/sharp-libvips-linux-arm64@1.2.4:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@img/sharp-libvips-linux-arm@1.0.5:
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@img/sharp-libvips-linux-arm@1.2.4:
@@ -1735,12 +1789,26 @@ packages:
     dev: false
     optional: true
 
+  /@img/sharp-libvips-linux-s390x@1.0.4:
+    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@img/sharp-libvips-linux-s390x@1.2.4:
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@img/sharp-libvips-linux-x64@1.0.4:
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@img/sharp-libvips-linux-x64@1.2.4:
@@ -1751,6 +1819,13 @@ packages:
     dev: false
     optional: true
 
+  /@img/sharp-libvips-linuxmusl-arm64@1.0.4:
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@img/sharp-libvips-linuxmusl-arm64@1.2.4:
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
@@ -1759,12 +1834,29 @@ packages:
     dev: false
     optional: true
 
+  /@img/sharp-libvips-linuxmusl-x64@1.0.4:
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@img/sharp-libvips-linuxmusl-x64@1.2.4:
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@img/sharp-linux-arm64@0.33.5:
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
     optional: true
 
   /@img/sharp-linux-arm64@0.34.5:
@@ -1776,6 +1868,16 @@ packages:
     optionalDependencies:
       '@img/sharp-libvips-linux-arm64': 1.2.4
     dev: false
+    optional: true
+
+  /@img/sharp-linux-arm@0.33.5:
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
     optional: true
 
   /@img/sharp-linux-arm@0.34.5:
@@ -1811,6 +1913,16 @@ packages:
     dev: false
     optional: true
 
+  /@img/sharp-linux-s390x@0.33.5:
+    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+    optional: true
+
   /@img/sharp-linux-s390x@0.34.5:
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -1820,6 +1932,16 @@ packages:
     optionalDependencies:
       '@img/sharp-libvips-linux-s390x': 1.2.4
     dev: false
+    optional: true
+
+  /@img/sharp-linux-x64@0.33.5:
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
     optional: true
 
   /@img/sharp-linux-x64@0.34.5:
@@ -1833,6 +1955,16 @@ packages:
     dev: false
     optional: true
 
+  /@img/sharp-linuxmusl-arm64@0.33.5:
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
   /@img/sharp-linuxmusl-arm64@0.34.5:
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -1844,6 +1976,16 @@ packages:
     dev: false
     optional: true
 
+  /@img/sharp-linuxmusl-x64@0.33.5:
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
   /@img/sharp-linuxmusl-x64@0.34.5:
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -1853,6 +1995,15 @@ packages:
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
     dev: false
+    optional: true
+
+  /@img/sharp-wasm32@0.33.5:
+    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+    requiresBuild: true
+    dependencies:
+      '@emnapi/runtime': 1.11.1
     optional: true
 
   /@img/sharp-wasm32@0.34.5:
@@ -1874,6 +2025,14 @@ packages:
     dev: false
     optional: true
 
+  /@img/sharp-win32-ia32@0.33.5:
+    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@img/sharp-win32-ia32@0.34.5:
     resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -1881,6 +2040,14 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@img/sharp-win32-x64@0.33.5:
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
     optional: true
 
   /@img/sharp-win32-x64@0.34.5:
@@ -4984,12 +5151,25 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
+  /color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.4
+
   /color-string@2.1.4:
     resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
     engines: {node: '>=18'}
     dependencies:
       color-name: 2.1.0
     dev: true
+
+  /color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
 
   /color@5.0.3:
     resolution: {integrity: sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==}
@@ -7551,7 +7731,7 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /image-minimizer-webpack-plugin@3.8.3(@squoosh/lib@0.5.3)(webpack@5.108.3):
+  /image-minimizer-webpack-plugin@3.8.3(@squoosh/lib@0.5.3)(sharp@0.33.5)(webpack@5.108.3):
     resolution: {integrity: sha512-Ex0cjNJc2FUSuwN7WHNyxkIZINP0M9lrN+uWJznMcsehiM5Z7ELwk+SEkSGEookK1GUd2wf+09jy1PEH5a5XmQ==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -7573,6 +7753,7 @@ packages:
       '@squoosh/lib': 0.5.3
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
+      sharp: 0.33.5
       webpack: 5.108.3(postcss@8.5.16)
     dev: false
 
@@ -7672,6 +7853,9 @@ packages:
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  /is-arrayish@0.3.4:
+    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
   /is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
@@ -11226,6 +11410,35 @@ packages:
       - typescript
     dev: false
 
+  /sharp@0.33.5:
+    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    requiresBuild: true
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-s390x': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-wasm32': 0.33.5
+      '@img/sharp-win32-ia32': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+
   /sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -11319,6 +11532,11 @@ packages:
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  /simple-swizzle@0.2.4:
+    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
+    dependencies:
+      is-arrayish: 0.3.4
 
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}

--- a/scripts/backfill-optimize-images.js
+++ b/scripts/backfill-optimize-images.js
@@ -1,0 +1,400 @@
+#!/usr/bin/env node
+// One-off migration: resizes/recompresses to WebP every pre-existing
+// profile/project image that predates the fileUpload Cloud Function's
+// automatic optimization (functions/index.js + functions/lib/
+// imageOptimize.js). Walks the whole bucket once (same full-bucket
+// scan style as backfill-file-records.js / convert-legacy-files.js,
+// skipping `courses/` and the legacy singular `profilephoto/`/
+// `project/` prefixes — none of those are resized by the live trigger
+// either), and for every eligible, not-yet-optimized image, downloads
+// it, resizes it with sharp per scripts/lib/imageOptimize.js's
+// targets, and overwrites the SAME object path in place — preserving
+// its `firebaseStorageDownloadTokens` metadata so every URL already
+// stored in Firestore (files/{id}.url, profile-pictures/{uid}.picture,
+// projects/{id}.project_photo) keeps working unchanged. Not a live
+// feature — run manually, once, from a maintainer's machine (or CI
+// with deploy credentials).
+//
+// Usage:
+//   node scripts/backfill-optimize-images.js [--execute] [--project <id>]
+//     [--bucket <name>]
+//
+// Defaults to a dry run (lists what would be resized, makes zero
+// writes). Pass --execute to actually overwrite the Storage objects.
+
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { execFileSync } = require('node:child_process')
+
+const {
+  isExcludedPath,
+  isDirectoryPlaceholder,
+  classifyObjectOwner,
+  isPhotoUrlForObject,
+} = require('./lib/fileRecordBackfill')
+const {
+  isThumbnailObjectPath,
+  WEBP_QUALITY,
+  PHOTO_DIMENSION,
+  GENERAL_MAX_DIMENSION,
+} = require('./lib/imageOptimize')
+
+function parseArgs(argv) {
+  const args = {
+    execute: false,
+    project: undefined,
+    bucket: undefined,
+  }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--execute') {
+      args.execute = true
+    } else if (arg === '--project') {
+      args.project = argv[++i]
+    } else if (arg === '--bucket') {
+      args.bucket = argv[++i]
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+  return args
+}
+
+// Dependency-free .env.local loader — this script runs standalone
+// (plain `node`, not the Next build), and dotenv isn't a repo
+// dependency. Shell/CI env vars already set win over the file, matching
+// dotenv's own precedence.
+function loadEnvLocal(repoRoot) {
+  const envPath = path.join(repoRoot, '.env.local')
+  if (!fs.existsSync(envPath)) return
+  const contents = fs.readFileSync(envPath, 'utf8')
+  for (const rawLine of contents.split('\n')) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+    const eq = line.indexOf('=')
+    if (eq === -1) continue
+    const key = line.slice(0, eq).trim()
+    let value = line.slice(eq + 1).trim()
+    const quoted =
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    if (quoted) value = value.slice(1, -1)
+    if (!(key in process.env)) process.env[key] = value
+  }
+}
+
+// Prefers real Application Default Credentials (`gcloud auth
+// application-default login`, or GOOGLE_APPLICATION_CREDENTIALS
+// pointing at a service account key) when present. Falls back to a
+// pre-fetched GCLOUD_ACCESS_TOKEN env var (handy when running inside a
+// container that has no gcloud CLI — fetch the token on the host with
+// `gcloud auth print-access-token` and pass it through), then to the
+// gcloud CLI's own user login (`gcloud auth login` — a separate, more
+// commonly-already-done step) by re-shelling to
+// `gcloud auth print-access-token` on every token fetch, which
+// naturally handles refresh across a long-running scan without caching
+// an expiring token.
+function resolveCredential(admin) {
+  const adcEnv = process.env.GOOGLE_APPLICATION_CREDENTIALS
+  const adcDefaultPath = path.join(
+    os.homedir(),
+    '.config',
+    'gcloud',
+    'application_default_credentials.json'
+  )
+  if (
+    (adcEnv && fs.existsSync(adcEnv)) ||
+    fs.existsSync(adcDefaultPath)
+  ) {
+    return admin.credential.applicationDefault()
+  }
+
+  if (process.env.GCLOUD_ACCESS_TOKEN) {
+    console.log(
+      'No Application Default Credentials found — using the static GCLOUD_ACCESS_TOKEN env var.'
+    )
+    const token = process.env.GCLOUD_ACCESS_TOKEN
+    return {
+      getAccessToken: async () => ({
+        access_token: token,
+        expires_in: 3600,
+      }),
+    }
+  }
+
+  try {
+    execFileSync('gcloud', ['--version'], { stdio: 'pipe' })
+  } catch {
+    throw new Error(
+      'No Application Default Credentials found, and the gcloud CLI is not on PATH.\n' +
+        'Run `gcloud auth application-default login`, set GOOGLE_APPLICATION_CREDENTIALS ' +
+        'to a service account key, set GCLOUD_ACCESS_TOKEN to a pre-fetched token, or ' +
+        'install the gcloud CLI and run `gcloud auth login`.'
+    )
+  }
+  console.log(
+    'No Application Default Credentials found — falling back to ' +
+      '`gcloud auth print-access-token` (gcloud auth login).'
+  )
+  return {
+    getAccessToken: async () => {
+      const token = execFileSync(
+        'gcloud',
+        ['auth', 'print-access-token'],
+        { stdio: ['ignore', 'pipe', 'pipe'] }
+      )
+        .toString()
+        .trim()
+      return { access_token: token, expires_in: 3600 }
+    },
+  }
+}
+
+// Reads the owner doc's photo-url field once per distinct ownerId and
+// caches the result (including "doesn't exist" / null) so a bucket
+// with thousands of files under the same project only costs one read
+// per project, not one per file.
+function makeOwnerPhotoLookup(db) {
+  const cache = new Map()
+
+  return async function getOwnerPhotoUrl(kind, ownerId) {
+    const cacheKey = `${kind}:${ownerId}`
+    if (cache.has(cacheKey)) return cache.get(cacheKey)
+
+    let result
+    if (kind === 'project') {
+      const snap = await db
+        .collection('projects')
+        .doc(ownerId)
+        .get()
+      result = snap.exists
+        ? { photoUrl: snap.data()?.project_photo }
+        : { photoUrl: undefined }
+    } else {
+      const snap = await db
+        .collection('profile-pictures')
+        .doc(ownerId)
+        .get()
+      result = snap.exists
+        ? { photoUrl: snap.data()?.picture }
+        : { photoUrl: undefined }
+    }
+    cache.set(cacheKey, result)
+    return result
+  }
+}
+
+// Resolves whether a pre-existing object is the display photo. The
+// `files/{basename}` Firestore record (if backfilled/present) is the
+// primary source of truth; falling back to a URL match against the
+// owner's photo-pointer field covers objects that predate that
+// subcollection too (same fallback backfill-file-records.js uses).
+async function resolveIsPhoto({
+  db,
+  ownerCollection,
+  ownerId,
+  basename,
+  objectName,
+  getOwnerPhotoUrl,
+}) {
+  const fileDoc = await db
+    .collection(ownerCollection)
+    .doc(ownerId)
+    .collection('files')
+    .doc(basename)
+    .get()
+  if (fileDoc.exists) {
+    return Boolean(fileDoc.data()?.isPhoto)
+  }
+  const { photoUrl } = await getOwnerPhotoUrl(
+    ownerCollection === 'projects' ? 'project' : 'profile',
+    ownerId
+  )
+  return isPhotoUrlForObject(photoUrl, objectName)
+}
+
+// Resizes one Storage object in place to WebP, preserving (or
+// minting, if absent) its download token — identical strategy to
+// functions/index.js#optimizeImageObject, so the rewritten object
+// keeps serving from the exact same URL every existing Firestore
+// record/pointer field already points at.
+async function optimizeObject({ bucket, object, isPhoto }) {
+  const sharp = require('sharp')
+  const file = bucket.file(object.name)
+
+  const [buffer] = await file.download()
+  const target = isPhoto
+    ? {
+        width: PHOTO_DIMENSION,
+        height: PHOTO_DIMENSION,
+        fit: 'cover',
+      }
+    : {
+        width: GENERAL_MAX_DIMENSION,
+        height: GENERAL_MAX_DIMENSION,
+        fit: 'inside',
+        withoutEnlargement: true,
+      }
+  const webpBuffer = await sharp(buffer)
+    .resize(target)
+    .webp({ quality: WEBP_QUALITY })
+    .toBuffer()
+
+  const [freshMetadata] = await file.getMetadata()
+  const existingTokens =
+    freshMetadata.metadata?.firebaseStorageDownloadTokens
+  const token = existingTokens
+    ? existingTokens.split(',')[0]
+    : require('node:crypto').randomUUID()
+
+  await file.save(webpBuffer, {
+    contentType: 'image/webp',
+    metadata: {
+      cacheControl: freshMetadata.cacheControl,
+      metadata: {
+        ...freshMetadata.metadata,
+        optimized: 'true',
+        firebaseStorageDownloadTokens: token,
+      },
+    },
+  })
+
+  return { before: buffer.length, after: webpBuffer.length }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  loadEnvLocal(path.resolve(__dirname, '..'))
+
+  const projectId =
+    args.project || process.env.NEXT_PUBLIC_FB_PROJECT_ID
+  if (!projectId) {
+    throw new Error(
+      'No project id: pass --project <id> or set NEXT_PUBLIC_FB_PROJECT_ID (e.g. via .env.local).'
+    )
+  }
+  const bucketName =
+    args.bucket || `${projectId}.appspot.com`
+
+  const admin = require('firebase-admin')
+  admin.initializeApp({
+    credential: resolveCredential(admin),
+    projectId,
+    storageBucket: bucketName,
+  })
+  const bucket = admin.storage().bucket()
+  const db = admin.firestore()
+  const getOwnerPhotoUrl = makeOwnerPhotoLookup(db)
+
+  console.log(
+    `${
+      args.execute ? '[EXECUTE]' : '[DRY RUN]'
+    } scanning gs://${bucketName}/ ...`
+  )
+
+  const [objects] = await bucket.getFiles()
+
+  const counts = {
+    scanned: 0,
+    optimized: 0,
+    alreadyOptimized: 0,
+    skippedNotImage: 0,
+    skippedUnowned: 0,
+    failed: 0,
+  }
+
+  for (const object of objects) {
+    if (
+      isExcludedPath(object.name) ||
+      isDirectoryPlaceholder(object.name) ||
+      isThumbnailObjectPath(object.name)
+    ) {
+      continue
+    }
+
+    const owner = classifyObjectOwner(object.name)
+    if (owner.kind === null) {
+      continue
+    }
+    counts.scanned++
+
+    const metadata =
+      object.metadata && object.metadata.contentType
+        ? object.metadata
+        : (await object.getMetadata())[0]
+
+    if (!metadata.contentType?.startsWith('image/')) {
+      counts.skippedNotImage++
+      continue
+    }
+    if (metadata.metadata?.optimized === 'true') {
+      counts.alreadyOptimized++
+      continue
+    }
+
+    const basename = path.posix.basename(object.name)
+    const ownerCollection =
+      owner.kind === 'project' ? 'projects' : 'profiles'
+
+    try {
+      const isPhoto = await resolveIsPhoto({
+        db,
+        ownerCollection,
+        ownerId: owner.ownerId,
+        basename,
+        objectName: object.name,
+        getOwnerPhotoUrl,
+      })
+
+      if (!args.execute) {
+        console.log(
+          `[DRY RUN] would resize ${object.name} to ` +
+            `${
+              isPhoto
+                ? `${PHOTO_DIMENSION}x${PHOTO_DIMENSION} (photo)`
+                : `<=${GENERAL_MAX_DIMENSION}px (gallery)`
+            }, contentType=${
+              metadata.contentType
+            } -> image/webp`
+        )
+        counts.optimized++
+        continue
+      }
+
+      const { before, after } = await optimizeObject({
+        bucket,
+        object,
+        isPhoto,
+      })
+      console.log(
+        `optimized ${object.name}: ${before}B -> ${after}B` +
+          (isPhoto ? ' (photo)' : '')
+      )
+      counts.optimized++
+    } catch (err) {
+      counts.failed++
+      console.error(
+        `FAILED to optimize ${object.name}: ${err.message}`
+      )
+    }
+  }
+
+  console.log(
+    `\nSummary: scanned=${counts.scanned} optimized=${counts.optimized} ` +
+      `already-optimized=${counts.alreadyOptimized} skipped-not-image=${counts.skippedNotImage} ` +
+      `failed=${counts.failed}` +
+      (args.execute ? '' : ' (dry run — no writes made)')
+  )
+
+  if (counts.failed > 0) process.exitCode = 1
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err.message || err)
+    process.exitCode = 1
+  })
+}
+
+module.exports = { parseArgs, loadEnvLocal }

--- a/scripts/lib/imageOptimize.js
+++ b/scripts/lib/imageOptimize.js
@@ -1,0 +1,64 @@
+// Pure resize/recompress target logic for images uploaded to Storage.
+// Mirrors functions/lib/imageOptimize.js (the live fileUpload trigger)
+// — kept as a separate copy since functions/ and the top-level
+// scripts/ are independently deployed/run (see firebase.json's
+// `functions.source`), same as the rest of scripts/lib/. Keep the two
+// in sync by hand if these numbers ever change.
+//
+// - Profile/project "display photo" (uploaded to a `.../photo/`
+//   subpath — see context/helpers.js#getUploadStoragePath): shown at
+//   most at 96px (components/ProfilePhoto.js) / 160px (ProjectCard,
+//   desktop). 400x400 covers up to ~4x pixel density at the largest
+//   on-site usage while staying tiny.
+// - Any other uploaded image (profile/project gallery file): shown up
+//   to 768px wide (project detail hero, FileGallery's lightbox
+//   `max-w-3xl`). 1600px longest edge covers ~2x retina at that size.
+const PHOTO_DIMENSION = 400
+const GENERAL_MAX_DIMENSION = 1600
+const WEBP_QUALITY = 82
+
+function isPhotoObjectPath(objectPath) {
+  return /\/photo\//.test(objectPath)
+}
+
+function isThumbnailObjectPath(objectPath) {
+  return /\/thumbnails\//.test(objectPath)
+}
+
+// profiles/{uid}/... or projects/{projectId}/... (flat, or the
+// /photo/ subpath above), excluding /thumbnails/ — the only prefixes
+// this migration/trigger ever resizes. courses/ (Prismic-managed) and
+// the legacy singular profilephoto//project/ prefixes are left
+// untouched.
+function isResizeEligiblePath(objectPath) {
+  if (isThumbnailObjectPath(objectPath)) return false
+  return (
+    /^profiles\//.test(objectPath) ||
+    /^projects\//.test(objectPath)
+  )
+}
+
+function getResizeTarget(objectPath) {
+  return isPhotoObjectPath(objectPath)
+    ? {
+        width: PHOTO_DIMENSION,
+        height: PHOTO_DIMENSION,
+        fit: 'cover',
+      }
+    : {
+        width: GENERAL_MAX_DIMENSION,
+        height: GENERAL_MAX_DIMENSION,
+        fit: 'inside',
+        withoutEnlargement: true,
+      }
+}
+
+module.exports = {
+  PHOTO_DIMENSION,
+  GENERAL_MAX_DIMENSION,
+  WEBP_QUALITY,
+  isPhotoObjectPath,
+  isThumbnailObjectPath,
+  isResizeEligiblePath,
+  getResizeTarget,
+}

--- a/scripts/lib/imageOptimize.test.js
+++ b/scripts/lib/imageOptimize.test.js
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import {
+  GENERAL_MAX_DIMENSION,
+  PHOTO_DIMENSION,
+  getResizeTarget,
+  isPhotoObjectPath,
+  isResizeEligiblePath,
+  isThumbnailObjectPath,
+} from './imageOptimize'
+
+describe('isPhotoObjectPath', () => {
+  it('matches a profile display photo path', () => {
+    expect(
+      isPhotoObjectPath('profiles/uid1/photo/abc.jpg')
+    ).toBe(true)
+  })
+
+  it('matches a project display photo path', () => {
+    expect(
+      isPhotoObjectPath('projects/proj1/photo/abc.jpg')
+    ).toBe(true)
+  })
+
+  it('rejects a flat gallery file', () => {
+    expect(isPhotoObjectPath('profiles/uid1/abc.jpg')).toBe(
+      false
+    )
+  })
+})
+
+describe('isThumbnailObjectPath', () => {
+  it('matches a PDF thumbnail path', () => {
+    expect(
+      isThumbnailObjectPath(
+        'profiles/uid1/thumbnails/abc.png'
+      )
+    ).toBe(true)
+  })
+
+  it('rejects a non-thumbnail path', () => {
+    expect(
+      isThumbnailObjectPath('profiles/uid1/abc.jpg')
+    ).toBe(false)
+  })
+})
+
+describe('isResizeEligiblePath', () => {
+  it('accepts a flat profile file', () => {
+    expect(
+      isResizeEligiblePath('profiles/uid1/abc.jpg')
+    ).toBe(true)
+  })
+
+  it('accepts a profile photo subpath', () => {
+    expect(
+      isResizeEligiblePath('profiles/uid1/photo/abc.jpg')
+    ).toBe(true)
+  })
+
+  it('accepts a flat project file', () => {
+    expect(
+      isResizeEligiblePath('projects/proj1/abc.jpg')
+    ).toBe(true)
+  })
+
+  it('rejects a thumbnail path', () => {
+    expect(
+      isResizeEligiblePath(
+        'projects/proj1/thumbnails/abc.png'
+      )
+    ).toBe(false)
+  })
+
+  it('rejects course assets', () => {
+    expect(
+      isResizeEligiblePath('courses/bio-101/abc.jpg')
+    ).toBe(false)
+  })
+
+  it('rejects the legacy singular profilephoto prefix', () => {
+    expect(
+      isResizeEligiblePath('profilephoto/uid1.jpg')
+    ).toBe(false)
+  })
+
+  it('rejects the legacy singular project prefix', () => {
+    expect(
+      isResizeEligiblePath('project/proj1/abc.jpg')
+    ).toBe(false)
+  })
+})
+
+describe('getResizeTarget', () => {
+  it('returns a fixed square cover target for a photo path', () => {
+    expect(
+      getResizeTarget('profiles/uid1/photo/abc.jpg')
+    ).toEqual({
+      width: PHOTO_DIMENSION,
+      height: PHOTO_DIMENSION,
+      fit: 'cover',
+    })
+  })
+
+  it('returns a bounded, non-enlarging target for a gallery path', () => {
+    expect(
+      getResizeTarget('profiles/uid1/abc.jpg')
+    ).toEqual({
+      width: GENERAL_MAX_DIMENSION,
+      height: GENERAL_MAX_DIMENSION,
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+  })
+})

--- a/storage.rules
+++ b/storage.rules
@@ -3,8 +3,10 @@ rules_version = '2';
 // SciTeens Cloud Storage Security Rules
 //
 // Upload paths (client):
-//   profiles/{uid}/<filename>            — profile files + profile photo
-//   projects/{projectId}/<filename>      — project files + project photo
+//   profiles/{uid}/<filename>            — profile files
+//   profiles/{uid}/photo/<filename>      — profile display photo
+//   projects/{projectId}/<filename>      — project files
+//   projects/{projectId}/photo/<filename> — project display photo
 // Upload paths (server / legacy):
 //   profilephoto/{uid}.<ext>             — legacy profile photo
 //   courses/{slug}/<filename>            — course assets (Prismic webhook)
@@ -46,10 +48,19 @@ service firebase.storage {
     // Only the profile owner may upload to their prefix. Non-recursive
     // {fileName} (one path segment) is deliberate — Storage rules grant
     // access if ANY matching statement allows it (there's no "most
-    // specific wins"), so this must not also match thumbnails/** or its
-    // looser 8MB/any-allowlisted-type budget would swallow the tighter
-    // thumbnail rule above it.
+    // specific wins"), so this must not also match thumbnails/**, photo/**,
+    // or their tighter budgets would be swallowed by this looser one.
     match /profiles/{uid}/{fileName} {
+      allow read: if true;
+      allow write: if request.auth.uid == uid && isValidUpload();
+      allow delete: if request.auth.uid == uid;
+    }
+
+    // The current display photo, uploaded to its own subpath (see
+    // context/helpers.js#getUploadStoragePath) so the fileUpload Cloud
+    // Function can tell it apart from a gallery file and resize it down
+    // to the small dimensions it's actually ever displayed at.
+    match /profiles/{uid}/photo/{fileName} {
       allow read: if true;
       allow write: if request.auth.uid == uid && isValidUpload();
       allow delete: if request.auth.uid == uid;
@@ -80,6 +91,23 @@ service firebase.storage {
     }
 
     match /projects/{projectId}/{fileName} {
+      allow read: if true;
+      allow write: if request.auth != null
+        && request.auth.uid in
+            firestore.get(/databases/(default)/documents/projects/$(projectId))
+              .data.member_uids
+        && isValidUpload();
+      allow delete: if request.auth != null
+        && request.auth.uid in
+            firestore.get(/databases/(default)/documents/projects/$(projectId))
+              .data.member_uids;
+    }
+
+    // The current display photo, uploaded to its own subpath (see
+    // context/helpers.js#getUploadStoragePath) so the fileUpload Cloud
+    // Function can tell it apart from a gallery file and resize it down
+    // to the small dimensions it's actually ever displayed at.
+    match /projects/{projectId}/photo/{fileName} {
       allow read: if true;
       allow write: if request.auth != null
         && request.auth.uid in

--- a/tests/rules/storage.rules.test.js
+++ b/tests/rules/storage.rules.test.js
@@ -224,6 +224,92 @@ describe('/profiles/{uid}/thumbnails/{fileName=**}', () => {
   })
 })
 
+describe('/profiles/{uid}/photo/{fileName=**}', () => {
+  it('owner can upload an allowlisted, in-budget display photo', async () => {
+    const storage = ctxStorage('alice')
+    await assertSucceeds(
+      uploadBytes(
+        ref(storage, 'profiles/alice/photo/f1.png'),
+        PNG_BYTES,
+        { contentType: 'image/png' }
+      )
+    )
+  })
+
+  it('rejects upload from a different uid', async () => {
+    const storage = ctxStorage('mallory')
+    await assertFails(
+      uploadBytes(
+        ref(storage, 'profiles/alice/photo/f1.png'),
+        PNG_BYTES,
+        { contentType: 'image/png' }
+      )
+    )
+  })
+
+  it('rejects a disallowed content type', async () => {
+    const storage = ctxStorage('alice')
+    await assertFails(
+      uploadBytes(
+        ref(storage, 'profiles/alice/photo/f1.docx'),
+        PNG_BYTES,
+        {
+          contentType:
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        }
+      )
+    )
+  })
+
+  it('is publicly readable', async () => {
+    await testEnv.withSecurityRulesDisabled(
+      async (context) =>
+        uploadBytes(
+          ref(
+            context.storage(),
+            'profiles/alice/photo/f1.png'
+          ),
+          PNG_BYTES,
+          { contentType: 'image/png' }
+        )
+    )
+    const storage = ctxStorage(null)
+    await assertSucceeds(
+      getBytes(ref(storage, 'profiles/alice/photo/f1.png'))
+    )
+  })
+
+  it('only the owner can delete', async () => {
+    await testEnv.withSecurityRulesDisabled(
+      async (context) =>
+        uploadBytes(
+          ref(
+            context.storage(),
+            'profiles/alice/photo/f1.png'
+          ),
+          PNG_BYTES,
+          { contentType: 'image/png' }
+        )
+    )
+    await assertFails(
+      deleteObject(
+        ref(
+          ctxStorage('mallory'),
+          'profiles/alice/photo/f1.png'
+        )
+      )
+    )
+    await assertSucceeds(
+      deleteObject(
+        ref(
+          ctxStorage('alice'),
+          'profiles/alice/photo/f1.png'
+        )
+      )
+    )
+  })
+})
+
 describe('/projects/{projectId}/{fileName=**}', () => {
   it('a member can upload an allowlisted, in-budget file', async () => {
     await seedProject('p1', ['alice'])
@@ -331,6 +417,74 @@ describe('/projects/{projectId}/thumbnails/{fileName=**}', () => {
         ref(storage, 'projects/p1/thumbnails/f1.png'),
         PNG_BYTES,
         { contentType: 'image/png' }
+      )
+    )
+  })
+})
+
+describe('/projects/{projectId}/photo/{fileName=**}', () => {
+  it('a member can upload an allowlisted, in-budget display photo', async () => {
+    await seedProject('p1', ['alice'])
+    const storage = ctxStorage('alice')
+    await assertSucceeds(
+      uploadBytes(
+        ref(storage, 'projects/p1/photo/f1.png'),
+        PNG_BYTES,
+        { contentType: 'image/png' }
+      )
+    )
+  })
+
+  it('rejects upload from a non-member', async () => {
+    await seedProject('p1', ['alice'])
+    const storage = ctxStorage('mallory')
+    await assertFails(
+      uploadBytes(
+        ref(storage, 'projects/p1/photo/f1.png'),
+        PNG_BYTES,
+        { contentType: 'image/png' }
+      )
+    )
+  })
+
+  it('rejects a disallowed content type even from a member', async () => {
+    await seedProject('p1', ['alice'])
+    const storage = ctxStorage('alice')
+    await assertFails(
+      uploadBytes(
+        ref(storage, 'projects/p1/photo/f1.ppt'),
+        PNG_BYTES,
+        {
+          contentType: 'application/vnd.ms-powerpoint',
+        }
+      )
+    )
+  })
+
+  it('only a member can delete', async () => {
+    await seedProject('p1', ['alice'])
+    await testEnv.withSecurityRulesDisabled(
+      async (context) =>
+        uploadBytes(
+          ref(
+            context.storage(),
+            'projects/p1/photo/f1.png'
+          ),
+          PNG_BYTES,
+          { contentType: 'image/png' }
+        )
+    )
+    await assertFails(
+      deleteObject(
+        ref(
+          ctxStorage('mallory'),
+          'projects/p1/photo/f1.png'
+        )
+      )
+    )
+    await assertSucceeds(
+      deleteObject(
+        ref(ctxStorage('alice'), 'projects/p1/photo/f1.png')
       )
     )
   })


### PR DESCRIPTION
Profile/project display photos are capped at 400x400 (largest they're ever shown on-site, ~4x retina headroom); other uploaded images are capped at 1600px longest edge. Both get recompressed to WebP via sharp in the fileUpload Cloud Function trigger, overwriting the Storage object in place (preserving its download token) so URLs the client already captured stay valid.

- context/helpers.js: getUploadStoragePath puts a display photo under its own photo/ subpath so the trigger can size it correctly without racing the client's Firestore isPhoto write.
- functions/index.js + functions/lib/imageOptimize.js: resize/webp logic in the fileUpload trigger, with a metadata flag guarding against re-triggering on its own overwrite.
- storage.rules: owner/member-gated photo/ subpath rules, mirroring the existing thumbnails/ convention.
- scripts/backfill-optimize-images.js: one-off migration for images uploaded before this existed (dry-run by default).