### PR TITLE
fix: stop dimming projects during background revalidation

### DIFF
--- a/pages/projects.js
+++ b/pages/projects.js
@@ -621,8 +621,8 @@ function Projects({ cached_projects }) {
             <div
               className={cn(
                 'transition-opacity',
-                projectsQuery.isFetching &&
-                  !loading &&
+                // Dim only while keepPreviousData holds a stale filter/sort page, not initial revalidation or next-page fetches.
+                projectsQuery.isPlaceholderData &&
                   'opacity-60'
               )}
             >


### PR DESCRIPTION
Gate list opacity on isPlaceholderData so initial data and next-page fetches stay fully visible; only dim while keepPreviousData serves a stale filter/sort page.