### PR TITLE
fix: project files skeleton, discussion profiles, upvote stickiness

### DIFF
--- a/components/Discussion.js
+++ b/components/Discussion.js
@@ -33,6 +33,35 @@ import { useTranslation } from 'next-i18next'
 import debounce from 'lodash.debounce'
 import moment from 'moment'
 
+function DiscussionAuthor({ uid, display }) {
+  const photo = (
+    <div className="mr-2 h-10 w-10 shrink-0">
+      <ProfilePhoto uid={uid} />
+    </div>
+  )
+
+  if (!uid) {
+    return (
+      <>
+        {photo}
+        <p className="font-semibold">{display}</p>
+      </>
+    )
+  }
+
+  return (
+    <a
+      href={`/profile/${uid}`}
+      className="flex min-w-0 flex-row items-center no-underline"
+    >
+      {photo}
+      <p className="text-sciteensGreen-regular hover:text-sciteensGreen-dark font-bold">
+        {display}
+      </p>
+    </a>
+  )
+}
+
 export default function Discussion({ type, item_id }) {
   const { data: signInCheckResult } = useSigninCheck()
   const { t } = useTranslation('common')
@@ -297,7 +326,7 @@ export default function Discussion({ type, item_id }) {
                 <Card
                   id={comment.id}
                   key={comment.date}
-                  className={`relative ${
+                  className={`border-border/60 relative shadow-sm ${
                     router.isReady &&
                     router.basePath.includes(comment.id)
                       ? 'ring-primary/50 ring-2'
@@ -310,14 +339,10 @@ export default function Discussion({ type, item_id }) {
                 >
                   <CardContent>
                     <div className="mb-2 flex flex-row items-center">
-                      <div className="mr-2 h-10 w-10">
-                        <ProfilePhoto
-                          uid={comment.uid}
-                        ></ProfilePhoto>
-                      </div>
-                      <p className="font-semibold">
-                        {comment.display}
-                      </p>
+                      <DiscussionAuthor
+                        uid={comment.uid}
+                        display={comment.display}
+                      />
                     </div>
                     <p className="text-muted-foreground absolute right-4 top-4 text-xs">
                       {moment(comment.date)
@@ -430,18 +455,14 @@ export default function Discussion({ type, item_id }) {
                             <Card
                               id={reply.id}
                               key={reply.date}
-                              className="relative mb-2 ml-auto"
+                              className="border-border/60 relative mb-2 ml-auto shadow-sm"
                             >
                               <CardContent>
                                 <div className="mb-2 flex flex-row items-center">
-                                  <div className="mr-2 h-10 w-10">
-                                    <ProfilePhoto
-                                      uid={reply.uid}
-                                    ></ProfilePhoto>
-                                  </div>
-                                  <p className="font-semibold">
-                                    {reply.display}
-                                  </p>
+                                  <DiscussionAuthor
+                                    uid={reply.uid}
+                                    display={reply.display}
+                                  />
                                 </div>
                                 <p>{reply.comment}</p>
                                 <p className="text-muted-foreground absolute right-4 top-4 text-xs">

--- a/components/Discussion.test.js
+++ b/components/Discussion.test.js
@@ -42,8 +42,12 @@ vi.mock('firebase/firestore', () => ({
   addDoc: vi.fn().mockResolvedValue(undefined),
 }))
 
+const { discussionState } = vi.hoisted(() => ({
+  discussionState: { data: [] },
+}))
+
 vi.mock('../lib/firestoreData', () => ({
-  useFirestoreCollectionData: () => ({ data: [] }),
+  useFirestoreCollectionData: () => discussionState,
 }))
 
 vi.mock('../context/AuthContext', () => ({
@@ -53,6 +57,12 @@ vi.mock('../context/AuthContext', () => ({
       user: { uid: 'u1', displayName: 'Test User' },
     },
   }),
+}))
+
+vi.mock('./ProfilePhoto', () => ({
+  default: ({ uid }) => (
+    <span data-testid={`photo-${uid || 'none'}`} />
+  ),
 }))
 
 class MockWorker {
@@ -89,6 +99,7 @@ function typeComment(text) {
 beforeEach(() => {
   vi.useFakeTimers()
   MockWorker.instances = []
+  discussionState.data = []
   vi.stubGlobal('Worker', MockWorker)
 })
 
@@ -247,4 +258,45 @@ describe('Discussion toxicity worker wiring', () => {
       ).not.toBeDisabled()
     }
   )
+})
+
+describe('Discussion author profile links', () => {
+  it('links comment and reply authors to their profile pages', () => {
+    discussionState.data = [
+      {
+        id: 'c1',
+        uid: 'author-1',
+        display: 'Ada Lovelace',
+        comment: 'Interesting project',
+        date: '2026-01-01T00:00:00.000Z',
+        reply_to_id: '',
+      },
+      {
+        id: 'r1',
+        uid: 'author-2',
+        display: 'Grace Hopper',
+        comment: 'Agreed',
+        date: '2026-01-02T00:00:00.000Z',
+        reply_to_id: 'c1',
+      },
+    ]
+
+    render(<Discussion type="projects" item_id="p1" />)
+
+    const authorLink = screen.getByRole('link', {
+      name: /Ada Lovelace/,
+    })
+    const replyLink = screen.getByRole('link', {
+      name: /Grace Hopper/,
+    })
+
+    expect(authorLink).toHaveAttribute(
+      'href',
+      '/profile/author-1'
+    )
+    expect(replyLink).toHaveAttribute(
+      'href',
+      '/profile/author-2'
+    )
+  })
 })

--- a/components/FileGallery.js
+++ b/components/FileGallery.js
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/carousel'
 import RenderFile, { getPreviewUrl } from './File'
 import { isLegacyUnsupportedFile } from '../context/helpers'
+import { Skeleton } from '@/components/ui/skeleton'
 
 const PdfThumbnail = dynamic(
   () => import('./PdfThumbnail'),
@@ -109,6 +110,25 @@ function ImageLightbox({ images, startIndex }) {
         )}
       </div>
     </>
+  )
+}
+
+// Placeholder grid matching the image thumbnail layout so the
+// surrounding page does not jump when file docs first arrive.
+export function FileGallerySkeleton({ count = 4 }) {
+  return (
+    <div
+      className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      {Array.from({ length: count }, (_, index) => (
+        <Skeleton
+          key={index}
+          className="aspect-square w-full rounded-xl"
+        />
+      ))}
+    </div>
   )
 }
 

--- a/components/FileGallery.test.js
+++ b/components/FileGallery.test.js
@@ -14,7 +14,9 @@ import {
   screen,
   within,
 } from '@testing-library/react'
-import FileGallery from './FileGallery'
+import FileGallery, {
+  FileGallerySkeleton,
+} from './FileGallery'
 
 vi.mock('next-i18next', () => ({
   useTranslation: () => ({ t: (key) => key }),
@@ -214,5 +216,24 @@ describe('FileGallery', () => {
 
     matchMediaSpy.mockRestore()
     openSpy.mockRestore()
+  })
+})
+
+describe('FileGallerySkeleton', () => {
+  it('reserves a four-tile image grid by default', () => {
+    const { container } = render(<FileGallerySkeleton />)
+    const tiles = container.querySelectorAll(
+      '[data-slot="skeleton"]'
+    )
+    expect(tiles).toHaveLength(4)
+  })
+
+  it('respects an explicit tile count', () => {
+    const { container } = render(
+      <FileGallerySkeleton count={2} />
+    )
+    expect(
+      container.querySelectorAll('[data-slot="skeleton"]')
+    ).toHaveLength(2)
   })
 })

--- a/components/ProjectUpvoteButton.js
+++ b/components/ProjectUpvoteButton.js
@@ -35,19 +35,28 @@ export default function ProjectUpvoteButton({
   const { data: upvoteDoc } = useFirestoreDocData(upvoteRef)
 
   const serverCount = normalizeUpvoteCount(count)
-  const serverUpvoted = Boolean(upvoteDoc)
+  // Missing docs are `null` (see mapDocSnapshot); never treat an empty
+  // object / residual cache hit as "no vote".
+  const serverUpvoted = upvoteDoc != null
 
-  // Optimistic overlay so the bolt flips immediately; cleared once the
-  // live upvote doc matches what we predicted.
+  // Optimistic overlay so the bolt flips immediately. Keep it until the
+  // live vote doc AND parent count prop both catch up — listing cards
+  // often pass a stale denormalized count after a local toggle.
   const [optimistic, setOptimistic] = useState(null)
   const [busy, setBusy] = useState(false)
 
   useEffect(() => {
     if (!optimistic) return
-    if (serverUpvoted === optimistic.upvoted) {
-      setOptimistic(null)
+    if (serverUpvoted !== optimistic.upvoted) return
+    if (
+      optimistic.upvoted
+        ? serverCount < optimistic.upvote_count
+        : serverCount > optimistic.upvote_count
+    ) {
+      return
     }
-  }, [serverUpvoted, optimistic])
+    setOptimistic(null)
+  }, [serverUpvoted, serverCount, optimistic])
 
   // Drop a stale optimistic state if the user signs out mid-click.
   useEffect(() => {

--- a/components/ProjectUpvoteButton.test.js
+++ b/components/ProjectUpvoteButton.test.js
@@ -37,7 +37,7 @@ vi.mock('../lib/firebase', () => ({
 vi.mock('../lib/firestoreData', () => ({
   useFirestoreDocData: vi.fn(() => ({
     status: 'success',
-    data: undefined,
+    data: null,
   })),
 }))
 
@@ -73,7 +73,7 @@ beforeEach(() => {
   })
   useFirestoreDocData.mockReturnValue({
     status: 'success',
-    data: undefined,
+    data: null,
   })
   toggleMock.mockResolvedValue({
     upvoted: true,
@@ -136,5 +136,47 @@ describe('ProjectUpvoteButton', () => {
         'u1'
       )
     })
+  })
+
+  it('keeps the optimistic upvote until the parent count catches up', async () => {
+    const { rerender } = render(
+      <ProjectUpvoteButton projectId="p1" count={0} />
+    )
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'projects.support',
+      })
+    )
+
+    await waitFor(() => {
+      expect(toggleMock).toHaveBeenCalled()
+    })
+
+    // Vote doc has arrived, but listing count prop is still stale.
+    useFirestoreDocData.mockReturnValue({
+      status: 'success',
+      data: { uid: 'u1', projectId: 'p1' },
+    })
+    rerender(
+      <ProjectUpvoteButton projectId="p1" count={0} />
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: 'projects.remove_support',
+      })
+    ).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText('1')).toBeInTheDocument()
+
+    // Parent finally reflects the denormalized count.
+    rerender(
+      <ProjectUpvoteButton projectId="p1" count={1} />
+    )
+    expect(
+      screen.getByRole('button', {
+        name: 'projects.remove_support',
+      })
+    ).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText('1')).toBeInTheDocument()
   })
 })

--- a/lib/firestoreData.js
+++ b/lib/firestoreData.js
@@ -5,9 +5,16 @@ import {
   useQueryClient,
 } from '@tanstack/react-query'
 
-function mapDocSnapshot(snapshot, idField) {
+// Missing docs must resolve to `null`, never `undefined`. TanStack Query
+// v5 rejects undefined queryFn results, and setQueryData(undefined) is a
+// no-op — both break consumers that treat doc presence as vote state.
+export function mapDocSnapshot(snapshot, idField) {
+  if (!snapshot?.exists?.()) {
+    return null
+  }
   let data = snapshot.data()
-  if (data && idField) {
+  if (!data) return null
+  if (idField) {
     data = { ...data, [idField]: snapshot.id }
   }
   return data
@@ -143,7 +150,7 @@ export function useFirestoreDocData(ref, options = {}) {
         )
       },
       (error) => {
-        queryClient.setQueryData(queryKey, undefined)
+        queryClient.setQueryData(queryKey, null)
         queryClient.invalidateQueries({ queryKey })
         console.error(
           'Firestore doc subscription failed:',

--- a/lib/firestoreData.test.js
+++ b/lib/firestoreData.test.js
@@ -12,6 +12,7 @@ import {
 import {
   getCollectionQueryKey,
   getDocQueryKey,
+  mapDocSnapshot,
 } from './firestoreData'
 
 // query()/collection()/doc() build client-side query descriptors and never
@@ -133,5 +134,34 @@ describe('getDocQueryKey', () => {
 
   it('never throws for a missing ref', () => {
     expect(() => getDocQueryKey(undefined)).not.toThrow()
+  })
+})
+
+describe('mapDocSnapshot', () => {
+  it('returns null for a missing document (never undefined)', () => {
+    const snapshot = {
+      exists: () => false,
+      data: () => undefined,
+      id: 'missing',
+    }
+    expect(mapDocSnapshot(snapshot)).toBeNull()
+    expect(mapDocSnapshot(snapshot, 'id')).toBeNull()
+  })
+
+  it('returns data and optionally attaches idField for existing docs', () => {
+    const snapshot = {
+      exists: () => true,
+      data: () => ({ uid: 'u1', projectId: 'p1' }),
+      id: 'u1',
+    }
+    expect(mapDocSnapshot(snapshot)).toEqual({
+      uid: 'u1',
+      projectId: 'p1',
+    })
+    expect(mapDocSnapshot(snapshot, 'id')).toEqual({
+      uid: 'u1',
+      projectId: 'p1',
+      id: 'u1',
+    })
   })
 })

--- a/pages/profile/[slug]/index.js
+++ b/pages/profile/[slug]/index.js
@@ -44,7 +44,9 @@ import {
   getLinkPlatformLabel,
   isAllowedLink,
 } from '../../../context/helpers'
-import FileGallery from '../../../components/FileGallery'
+import FileGallery, {
+  FileGallerySkeleton,
+} from '../../../components/FileGallery'
 import ProjectCard from '../../../components/ProjectCard'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -306,10 +308,7 @@ function Project({ profile }) {
         )}
         <div className="flex flex-col items-center space-y-2">
           {filesStatus === 'loading' ? (
-            <>
-              <Skeleton className="h-12 w-full" />
-              <Skeleton className="h-12 w-full" />
-            </>
+            <FileGallerySkeleton />
           ) : (
             <FileGallery
               files={galleryFiles.map((record) => ({

--- a/pages/project/[id]/index.js
+++ b/pages/project/[id]/index.js
@@ -22,7 +22,9 @@ import SocialMeta from '../../../components/SocialMeta'
 import Image from 'next/image'
 import Error from 'next/error'
 import Link from 'next/link'
-import FileGallery from '../../../components/FileGallery'
+import FileGallery, {
+  FileGallerySkeleton,
+} from '../../../components/FileGallery'
 import { ExternalLink, Pencil } from 'lucide-react'
 import ProjectUpvoteButton from '../../../components/ProjectUpvoteButton'
 import { useEffect, useMemo, useState } from 'react'
@@ -309,13 +311,15 @@ function Project({ query, initialProject }) {
 
       {/* Files */}
       <div className="mx-auto mb-4 mt-8 w-full px-4 md:w-2/3 lg:w-1/2 lg:px-0">
-        {filesStatus === 'success' &&
-          fileRecords.length > 0 && (
-            <h2 className="mb-2 text-lg font-semibold md:text-2xl">
-              {t('course.files')}
-            </h2>
-          )}
-        {filesStatus !== 'loading' && (
+        {(filesStatus === 'loading' ||
+          fileRecords.length > 0) && (
+          <h2 className="mb-2 text-lg font-semibold md:text-2xl">
+            {t('course.files')}
+          </h2>
+        )}
+        {filesStatus === 'loading' ? (
+          <FileGallerySkeleton />
+        ) : (
           <FileGallery
             files={fileRecords.map((record) => ({
               id: record.id,


### PR DESCRIPTION
Reserve FileGallery layout with skeletons, link discussion authors to profiles with ProjectCard styling, and map missing Firestore docs to null so TanStack Query and optimistic upvotes settle correctly.