### PR TITLE
feat: migrate transactional email and contacts from Mailjet to Resend

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -20,23 +20,19 @@ const meiliMasterKey = defineSecret('MEILI_MASTER_KEY')
 // Google
 const vision = require('@google-cloud/vision')
 
-// Mailjet — functions.config() was removed in firebase-functions v7, so
-// credentials are Secret Manager params instead. Secrets are only
-// readable at invocation time (after being bound via
-// `.runWith({ secrets: [...] })` on each export that needs them), so
-// the client is built lazily rather than at module load.
-const mailjetApiKey = defineSecret('MAILJET_APIKEY')
-const mailjetApiSecret = defineSecret('MAILJET_APISECRET')
-let mailjetClient
-function getMailjet() {
-  if (!mailjetClient) {
-    mailjetClient = require('node-mailjet').connect(
-      mailjetApiKey.value(),
-      mailjetApiSecret.value()
-    )
-  }
-  return mailjetClient
-}
+// Resend
+const {
+  resendApiKey,
+  sendEmail,
+  addContact,
+} = require('./lib/resend')
+const {
+  verifyEmailTemplate,
+  welcomeTemplate,
+  newFeedbackTemplate,
+  upcomingProgramTemplate,
+  projectUpdateTemplate,
+} = require('./lib/emailTemplates')
 
 // Prismic
 const Prismic = require('@prismicio/client')
@@ -302,24 +298,19 @@ exports.deleteProfile = functions.firestore
 
 exports.newUser = functions
   .runWith({
-    secrets: [mailjetApiKey, mailjetApiSecret],
+    secrets: [resendApiKey],
   })
   .auth.user()
   .onCreate(async (user) => {
+    const [firstName, ...rest] = (
+      user.displayName || ''
+    ).split(' ')
     await Promise.all([
-      getMailjet()
-        .post('contact', { version: 'v3' })
-        .request({
-          IsExcludedFromCampaigns: 'false',
-          Name: user.displayName,
-          Email: user.email,
-        })
-        .then((result) => {
-          console.log(result.body)
-        })
-        .catch((err) => {
-          console.log(err.statusCode)
-        }),
+      addContact({
+        email: user.email,
+        firstName,
+        lastName: rest.join(' '),
+      }),
       // Create a user ref in the database to
       // quickly query emails
       admin
@@ -353,7 +344,7 @@ exports.newUser = functions
 
 exports.newProfile = functions
   .runWith({
-    secrets: [mailjetApiKey, mailjetApiSecret],
+    secrets: [resendApiKey],
   })
   .firestore.document('profiles/{profileID}')
   .onCreate(async (profile) => {
@@ -373,40 +364,24 @@ exports.newProfile = functions
         email,
         actionCodeSettings
       )
-    const request = getMailjet()
-      .post('send', { version: 'v3.1' })
-      .request({
-        Messages: [
-          {
-            From: {
-              Email: 'noreply@sciteens.com',
-              Name: 'SciTeens',
-            },
-            To: [
-              {
-                Email: email,
-                Name: data.display ? data.display : email,
-              },
-            ],
-            TemplateID: 1267257,
-            TemplateLanguage: true,
-            Subject: 'Verify Email',
-            Variables: {
-              link: verification_link,
-            },
-          },
-        ],
-      })
-    await request
+    await sendEmail({
+      to: email,
+      toName: data.display ? data.display : email,
+      subject: 'Verify Email',
+      html: verifyEmailTemplate({
+        link: verification_link,
+      }),
+    })
 
-    // Add to all contact list
-    await getMailjet()
-      .post('listrecipient', { version: 'v3' })
-      .request({
-        IsUnsubscribed: 'false',
-        ContactAlt: email,
-        ListID: '10251294',
-      })
+    // Add to all-contacts audience
+    const [firstName, ...rest] = (
+      user.displayName || ''
+    ).split(' ')
+    await addContact({
+      email,
+      firstName,
+      lastName: rest.join(' '),
+    })
 
     // Handle sending emails based on user type
     switch (data.position) {
@@ -417,77 +392,30 @@ exports.newProfile = functions
         await admin
           .auth()
           .setCustomUserClaims(id, { mentor: true })
-        await getMailjet()
-          .post('listrecipient', { version: 'v3' })
-          .request({
-            IsUnsubscribed: 'false',
-            ContactAlt: email,
-            ListID: '10251293',
-          })
 
-        await getMailjet()
-          .post('send', { version: 'v3.1' })
-          .request({
-            Messages: [
-              {
-                From: {
-                  Email: 'noreply@sciteens.com',
-                  Name: 'SciTeens',
-                },
-                To: [
-                  {
-                    Email: email,
-                    Name: user.displayName
-                      ? user.displayName
-                      : email,
-                  },
-                ],
-                TemplateID: 3336350,
-                TemplateLanguage: true,
-                Subject: 'Welcome to SciTeens!',
-                Variables: {
-                  displayName: user.displayName,
-                },
-              },
-            ],
-          })
+        await sendEmail({
+          to: email,
+          toName: user.displayName
+            ? user.displayName
+            : email,
+          subject: 'Welcome to SciTeens!',
+          html: welcomeTemplate({
+            displayName: user.displayName,
+          }),
+        })
         break
       default:
-        await getMailjet()
-          .post('listrecipient', { version: 'v3' })
-          .request({
-            IsUnsubscribed: 'false',
-            ContactAlt: user.email,
-            ListID: '10251292',
-          })
-
         // Send student welcome
-        await getMailjet()
-          .post('send', { version: 'v3.1' })
-          .request({
-            Messages: [
-              {
-                From: {
-                  Email: 'noreply@sciteens.com',
-                  Name: 'SciTeens',
-                },
-                To: [
-                  {
-                    Email: email,
-                    Name: user.displayName
-                      ? user.displayName
-                      : email,
-                  },
-                ],
-                TemplateID: 3336347,
-                TemplateLanguage: true,
-                Subject: 'Welcome to SciTeens!',
-                Variables: {
-                  displayName: user.displayName,
-                },
-              },
-            ],
-          })
+        await sendEmail({
+          to: email,
+          toName: user.displayName
+            ? user.displayName
+            : email,
+          subject: 'Welcome to SciTeens!',
+          html: welcomeTemplate({
+            displayName: user.displayName,
+          }),
+        })
         break
     }
   })
@@ -609,7 +537,7 @@ exports.updateProgram = functions.firestore
 
 exports.newDiscussion = functions
   .runWith({
-    secrets: [mailjetApiKey, mailjetApiSecret],
+    secrets: [resendApiKey],
   })
   .firestore.document(
     'projects/{projectID}/discussion/{feedbackID}'
@@ -640,35 +568,18 @@ exports.newDiscussion = functions
         'Sending discussion email to user ' +
           originalComment.data().uid
       )
-      return getMailjet()
-        .post('send', { version: 'v3.1' })
-        .request({
-          Messages: [
-            {
-              From: {
-                Email: 'noreply@sciteens.com',
-                Name: 'SciTeens',
-              },
-              To: [
-                {
-                  Email: originalUser.email,
-                  Name: originalUser.displayName,
-                },
-              ],
-              TemplateID: 1525200,
-              TemplateLanguage: true,
-              Subject: 'New Feedback',
-              Variables: {
-                studentOrMentor:
-                  user.customClaims &&
-                  user.customClaims['mentor']
-                    ? 'mentor'
-                    : 'student',
-                projectLink: `https://sciteens.com/project/${context.params.projectID}#${event.id}`,
-              },
-            },
-          ],
-        })
+      return sendEmail({
+        to: originalUser.email,
+        toName: originalUser.displayName,
+        subject: 'New Feedback',
+        html: newFeedbackTemplate({
+          studentOrMentor:
+            user.customClaims && user.customClaims['mentor']
+              ? 'mentor'
+              : 'student',
+          projectLink: `https://sciteens.com/project/${context.params.projectID}#${event.id}`,
+        }),
+      })
     }
   })
 
@@ -682,7 +593,7 @@ exports.newDiscussion = functions
 */
 exports.scheduledProgramEmailer = functions
   .runWith({
-    secrets: [mailjetApiKey, mailjetApiSecret],
+    secrets: [resendApiKey],
   })
   .pubsub.schedule('5 0 * * *')
   .timeZone('America/New_York') // Users can choose timezone - default is America/Los_Angeles
@@ -709,34 +620,14 @@ exports.scheduledProgramEmailer = functions
               .auth()
               .getUser(sub)
               .then((user) => {
-                // Send using Mailjet API v3
-                getMailjet()
-                  .post('send', { version: 'v3.1' })
-                  .request({
-                    Messages: [
-                      {
-                        From: {
-                          Email: 'noreply@sciteens.com',
-                          Name: 'SciTeens',
-                        },
-                        To: [
-                          {
-                            Email: user.email,
-                            Name: user.displayName
-                              ? user.displayName
-                              : user.email,
-                          },
-                        ],
-                        TemplateID: 1219486,
-                        TemplateLanguage: true,
-                        Subject:
-                          'Upcoming Program Application',
-                        Variables: {
-                          link: link,
-                        },
-                      },
-                    ],
-                  })
+                sendEmail({
+                  to: user.email,
+                  toName: user.displayName
+                    ? user.displayName
+                    : user.email,
+                  subject: 'Upcoming Program Application',
+                  html: upcomingProgramTemplate({ link }),
+                })
                 // Add notification
                 admin
                   .firestore()
@@ -1047,7 +938,7 @@ exports.fileUpload = functions.storage
 */
 exports.newProjectInvite = functions
   .runWith({
-    secrets: [mailjetApiKey, mailjetApiSecret],
+    secrets: [resendApiKey],
   })
   .firestore.document('project-invites/{projectID}')
   .onCreate((event) => {
@@ -1105,36 +996,18 @@ exports.newProjectInvite = functions
 
       // Email the user that they've been added to a project
       // Send an email to the user
-      getMailjet()
-        .post('send', { version: 'v3.1' })
-        .request({
-          Messages: [
-            {
-              From: {
-                Email: 'noreply@sciteens.com',
-                Name: 'SciTeens',
-              },
-              To: [
-                {
-                  Email: email,
-                  Name: email,
-                },
-              ],
-              TemplateID: 1373653,
-              TemplateLanguage: true,
-              Subject: 'Project Update',
-              Variables: {
-                projectName: title,
-                projectLink:
-                  'https://sciteens.com/project/' +
-                  event.id,
-              },
-            },
-          ],
-        })
-        .catch((err) => {
-          console.log('mailjet error:' + err)
-        })
+      sendEmail({
+        to: email,
+        toName: email,
+        subject: 'Project Update',
+        html: projectUpdateTemplate({
+          projectName: title,
+          projectLink:
+            'https://sciteens.com/project/' + event.id,
+        }),
+      }).catch((err) => {
+        console.log('resend error:' + err)
+      })
     })
     // Delete project invite once finished
     return admin

--- a/functions/lib/emailTemplates.js
+++ b/functions/lib/emailTemplates.js
@@ -1,0 +1,69 @@
+// Simple inline HTML templates, standing in for the Mailjet-hosted
+// templates until Resend templates are built out. Kept intentionally
+// plain: a heading, a paragraph, and a single CTA link where relevant.
+
+const GREEN = '#2e7d32'
+
+function layout(bodyHtml) {
+  return `<!DOCTYPE html>
+<html>
+  <body style="font-family: sans-serif; color: #1a1a1a; max-width: 480px; margin: 0 auto;">
+    <p style="font-size: 20px; font-weight: bold; color: ${GREEN};">SciTeens</p>
+    ${bodyHtml}
+    <p style="font-size: 12px; color: #666;">SciTeens &middot; sciteens.org</p>
+  </body>
+</html>`
+}
+
+function button(href, label) {
+  return `<p><a href="${href}" style="display: inline-block; background: ${GREEN}; color: #fff; padding: 10px 20px; border-radius: 6px; text-decoration: none;">${label}</a></p>`
+}
+
+function verifyEmailTemplate({ link }) {
+  return layout(`
+    <p>Thanks for signing up! Please verify your email address to finish setting up your account.</p>
+    ${button(link, 'Verify Email')}
+  `)
+}
+
+function welcomeTemplate({ displayName }) {
+  return layout(`
+    <p>Hi ${displayName || 'there'},</p>
+    <p>Welcome to SciTeens! We're excited to have you join our community.</p>
+  `)
+}
+
+function newFeedbackTemplate({
+  studentOrMentor,
+  projectLink,
+}) {
+  return layout(`
+    <p>A ${studentOrMentor} left new feedback on your project.</p>
+    ${button(projectLink, 'View Feedback')}
+  `)
+}
+
+function upcomingProgramTemplate({ link }) {
+  return layout(`
+    <p>A program you're subscribed to has an application deadline coming up within the week.</p>
+    ${button(link, 'View Program')}
+  `)
+}
+
+function projectUpdateTemplate({
+  projectName,
+  projectLink,
+}) {
+  return layout(`
+    <p>You've been added to the project "${projectName}".</p>
+    ${button(projectLink, 'View Project')}
+  `)
+}
+
+module.exports = {
+  verifyEmailTemplate,
+  welcomeTemplate,
+  newFeedbackTemplate,
+  upcomingProgramTemplate,
+  projectUpdateTemplate,
+}

--- a/functions/lib/resend.js
+++ b/functions/lib/resend.js
@@ -1,0 +1,63 @@
+const { Resend } = require('resend')
+const {
+  defineSecret,
+} = require('firebase-functions/params')
+
+// functions.config() was removed in firebase-functions v7, so credentials
+// are a Secret Manager param instead. Secrets are only readable at
+// invocation time (after being bound via `.runWith({ secrets: [...] })`
+// on each export that needs them), so the client is built lazily rather
+// than at module load.
+const resendApiKey = defineSecret('RESEND_APIKEY')
+let resendClient
+function getResend() {
+  if (!resendClient) {
+    resendClient = new Resend(resendApiKey.value())
+  }
+  return resendClient
+}
+
+// Single Resend audience holding every contact who hasn't unsubscribed.
+// Mentor/student distinction is tracked via Firebase Auth custom claims,
+// not separate mailing lists.
+const CONTACTS_AUDIENCE_ID =
+  '8c384f39-b01c-4cc8-a97e-1c9660c85225'
+
+const FROM = 'SciTeens <noreply@sciteens.org>'
+
+async function sendEmail({ to, toName, subject, html }) {
+  return getResend().emails.send({
+    from: FROM,
+    to: toName ? `${toName} <${to}>` : to,
+    subject,
+    html,
+  })
+}
+
+// Adds (or upserts) a contact to the all-contacts audience. Never throws
+// on failure — email delivery/list membership is best-effort and must
+// not block the write that triggered it.
+async function addContact({ email, firstName, lastName }) {
+  try {
+    const result = await getResend().contacts.create({
+      audienceId: CONTACTS_AUDIENCE_ID,
+      email,
+      firstName,
+      lastName,
+      unsubscribed: false,
+    })
+    if (result.error) {
+      console.log('resend addContact error:', result.error)
+    }
+    return result
+  } catch (err) {
+    console.log('resend addContact error:', err)
+  }
+}
+
+module.exports = {
+  resendApiKey,
+  sendEmail,
+  addContact,
+  CONTACTS_AUDIENCE_ID,
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,7 +17,7 @@
     "axios": "^0.25.0",
     "firebase-admin": "^13.10.0",
     "firebase-functions": "^7.2.5",
-    "node-mailjet": "^3.4.1",
+    "resend": "^6.17.2",
     "sharp": "^0.33.5",
     "slugify": "^1.6.9"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,9 +201,9 @@ importers:
       firebase-functions:
         specifier: ^7.2.5
         version: 7.2.5(firebase-admin@13.10.0)
-      node-mailjet:
-        specifier: ^3.4.1
-        version: 3.4.1
+      resend:
+        specifier: ^6.17.2
+        version: 6.17.2
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
@@ -2871,11 +2871,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@noble/hashes@1.8.0:
-    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
-    engines: {node: ^14.21.3 || >=16}
-    dev: false
-
   /@nodable/entities@2.2.0:
     resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
     requiresBuild: true
@@ -2929,12 +2924,6 @@ packages:
   /@oxc-project/types@0.139.0:
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
     dev: true
-
-  /@paralleldrive/cuid2@2.3.1:
-    resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
-    dependencies:
-      '@noble/hashes': 1.8.0
-    dev: false
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -3282,6 +3271,10 @@ packages:
       web-streams-polyfill: 3.3.3
     dev: false
 
+  /@stablelib/base64@1.0.1:
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+    dev: false
+
   /@standard-schema/spec@1.1.0:
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
     dev: true
@@ -3531,11 +3524,6 @@ packages:
     dependencies:
       '@testing-library/dom': 10.4.1
     dev: true
-
-  /@tootallnate/once@1.1.2:
-    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
-    engines: {node: '>= 6'}
-    dev: false
 
   /@tootallnate/once@2.0.1:
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
@@ -4183,13 +4171,6 @@ packages:
       acorn: 7.4.1
     dev: true
 
-  /acorn-walk@8.3.5:
-    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
-    engines: {node: '>=0.4.0'}
-    dependencies:
-      acorn: 8.17.0
-    dev: false
-
   /acorn@7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
     engines: {node: '>=0.4.0'}
@@ -4471,10 +4452,6 @@ packages:
     resolution: {integrity: sha512-1Sd1LrodN0XYxYeZcN1J4xYZvmvTwD5tDWaPUGPIzH1mFsmzsPnVtd2exWhecMjtZk/wYWjNZJiD3b1SLCeJqg==}
     dev: true
 
-  /asap@2.0.6:
-    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
-    dev: false
-
   /assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -4489,6 +4466,7 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       tslib: 2.8.1
+    dev: true
 
   /ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
@@ -5212,10 +5190,6 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /component-emitter@1.3.1:
-    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
-    dev: false
-
   /compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
@@ -5349,10 +5323,6 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
-  /cookiejar@2.1.4:
-    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
-    dev: false
-
   /core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
     requiresBuild: true
@@ -5360,6 +5330,7 @@ packages:
 
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+    dev: true
 
   /cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
@@ -5482,11 +5453,6 @@ packages:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
     dev: true
 
-  /data-uri-to-buffer@3.0.1:
-    resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
-    engines: {node: '>= 6'}
-    dev: false
-
   /data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -5600,6 +5566,7 @@ packages:
 
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    dev: true
 
   /deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -5652,16 +5619,6 @@ packages:
       object-keys: 1.1.1
     dev: true
 
-  /degenerator@3.0.4:
-    resolution: {integrity: sha512-Z66uPeBfHZAHVmue3HPfyKu2Q0rC2cRxbTOsvmU/po5fvvcx27W4mIu9n0PUlQih4oUYvcG1BsbtVv8x7KDOSw==}
-    engines: {node: '>= 6'}
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 1.14.3
-      esprima: 4.0.1
-      vm2: 3.11.5
-    dev: false
-
   /degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
@@ -5696,13 +5653,6 @@ packages:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
     dev: true
-
-  /dezalgo@1.0.4:
-    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
-    dependencies:
-      asap: 2.0.6
-      wrappy: 1.0.2
-    dev: false
 
   /diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -6056,19 +6006,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /escodegen@1.14.3:
-    resolution: {integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==}
-    engines: {node: '>=4.0'}
-    hasBin: true
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 4.3.0
-      esutils: 2.0.3
-      optionator: 0.8.3
-    optionalDependencies:
-      source-map: 0.6.1
-    dev: false
-
   /escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
     engines: {node: '>=6.0'}
@@ -6285,6 +6222,7 @@ packages:
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -6534,9 +6472,10 @@ packages:
 
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    dev: true
 
-  /fast-safe-stringify@2.1.1:
-    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+  /fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
     dev: false
 
   /fast-text-encoding@1.0.6:
@@ -6630,11 +6569,6 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       tslib: 2.8.1
-    dev: false
-
-  /file-uri-to-path@2.0.0:
-    resolution: {integrity: sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==}
-    engines: {node: '>= 6'}
     dev: false
 
   /fill-range@7.1.1:
@@ -6947,21 +6881,13 @@ packages:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+    dev: true
 
   /formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
     dependencies:
       fetch-blob: 3.2.0
-
-  /formidable@2.1.5:
-    resolution: {integrity: sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==}
-    dependencies:
-      '@paralleldrive/cuid2': 2.3.1
-      dezalgo: 1.0.4
-      once: 1.4.0
-      qs: 6.15.3
-    dev: false
 
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -6993,15 +6919,6 @@ packages:
       universalify: 2.0.1
     dev: false
 
-  /fs-extra@8.1.0:
-    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
-    engines: {node: '>=6 <7 || >=8'}
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
-    dev: false
-
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
@@ -7020,14 +6937,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /ftp@0.3.10:
-    resolution: {integrity: sha512-faFVML1aBx2UoDStmLwv2Wptt4vw5x03xxX172nhA5Y5HBshW5JweqQ2W4xL4dezQTG8inJsuYcpPHHU3X5OTQ==}
-    engines: {node: '>=0.8.0'}
-    dependencies:
-      readable-stream: 1.1.14
-      xregexp: 2.0.0
-    dev: false
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -7225,20 +7134,6 @@ packages:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
     dev: true
-
-  /get-uri@3.0.2:
-    resolution: {integrity: sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==}
-    engines: {node: '>= 6'}
-    dependencies:
-      '@tootallnate/once': 1.1.2
-      data-uri-to-buffer: 3.0.1
-      debug: 4.4.3
-      file-uri-to-path: 2.0.0
-      fs-extra: 8.1.0
-      ftp: 0.3.10
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
@@ -7626,17 +7521,6 @@ packages:
   /http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
 
-  /http-proxy-agent@4.0.1:
-    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
-    engines: {node: '>= 6'}
-    dependencies:
-      '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
@@ -7833,10 +7717,6 @@ packages:
     resolution: {integrity: sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==}
     engines: {node: '>=4'}
     dev: true
-
-  /ip@1.1.9:
-    resolution: {integrity: sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==}
-    dev: false
 
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -8219,6 +8099,7 @@ packages:
 
   /isarray@0.0.1:
     resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
+    dev: true
 
   /isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -8865,12 +8746,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  /jsonfile@4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
-    optionalDependencies:
-      graceful-fs: 4.2.11
-    dev: false
-
   /jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
     dependencies:
@@ -8970,14 +8845,6 @@ packages:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
     dev: true
-
-  /levn@0.3.0:
-    resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      prelude-ls: 1.1.2
-      type-check: 0.3.2
-    dev: false
 
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -9417,6 +9284,7 @@ packages:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
     hasBin: true
+    dev: true
 
   /mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
@@ -9639,6 +9507,7 @@ packages:
   /netmask@2.1.1:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
+    dev: true
 
   /next-i18next@9.2.0(@types/react@19.2.17)(next@14.2.35)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-cWhrgxYz9IZZQ81Vc4NgogaKSANN827qHRkyVuoscOerJBHNMr7t3vO1szj/M1qnyE7yIV0NHczCS4VyqWbQAg==}
@@ -9800,17 +9669,6 @@ packages:
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
-
-  /node-mailjet@3.4.1:
-    resolution: {integrity: sha512-m+msgBJYgwFbIZBIPOnsGOtBt9xP03UqmkmuEcgTcLlr/U1GUJQrVI7cDFRgujybb9Cl1wl4thIGyM3wt6X+zQ==}
-    dependencies:
-      json-bigint: 1.0.0
-      qs: 6.15.3
-      superagent: 7.1.6
-      superagent-proxy: 3.0.0(superagent@7.1.6)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /node-releases@2.0.50:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
@@ -9994,18 +9852,6 @@ packages:
       yaml: 2.9.0
     dev: true
 
-  /optionator@0.8.3:
-    resolution: {integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      deep-is: 0.1.4
-      fast-levenshtein: 2.0.6
-      levn: 0.3.0
-      prelude-ls: 1.1.2
-      type-check: 0.3.2
-      word-wrap: 1.2.5
-    dev: false
-
   /optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -10098,23 +9944,6 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  /pac-proxy-agent@5.0.0:
-    resolution: {integrity: sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ==}
-    engines: {node: '>= 8'}
-    dependencies:
-      '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2
-      debug: 4.4.3
-      get-uri: 3.0.2
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
-      pac-resolver: 5.0.1
-      raw-body: 2.5.3
-      socks-proxy-agent: 5.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /pac-proxy-agent@7.2.0:
     resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
     engines: {node: '>= 14'}
@@ -10130,15 +9959,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /pac-resolver@5.0.1:
-    resolution: {integrity: sha512-cy7u00ko2KVgBAjuhevqpPeHIkCIqPe1v24cydhWjmeuzaBfmUWFCZJ1iAh5TuVzVZoUzXIW7K8sMYOZ84uZ9Q==}
-    engines: {node: '>= 8'}
-    dependencies:
-      degenerator: 3.0.4
-      ip: 1.1.9
-      netmask: 2.1.1
-    dev: false
 
   /pac-resolver@7.0.1:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
@@ -10405,6 +10225,10 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+    dev: false
+
   /postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
@@ -10466,11 +10290,6 @@ packages:
   /powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
-    dev: false
-
-  /prelude-ls@1.1.2:
-    resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
-    engines: {node: '>= 0.8.0'}
     dev: false
 
   /prelude-ls@1.2.1:
@@ -10666,22 +10485,6 @@ packages:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  /proxy-agent@5.0.0:
-    resolution: {integrity: sha512-gkH7BkvLVkSfX9Dk27W6TyNOWWZWRilRfk1XxGNWOYJ2TuedAv1yFpCaU9QSBmBe716XOTNpYNOzhysyw8xn7g==}
-    engines: {node: '>= 8'}
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
-      lru-cache: 5.1.1
-      pac-proxy-agent: 5.0.0
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 5.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /proxy-agent@6.5.0:
     resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
     engines: {node: '>= 14'}
@@ -10700,6 +10503,7 @@ packages:
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: true
 
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -10883,15 +10687,6 @@ packages:
     dependencies:
       loose-envify: 1.4.0
 
-  /readable-stream@1.1.14:
-    resolution: {integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==}
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 0.0.1
-      string_decoder: 0.10.31
-    dev: false
-
   /readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
     dependencies:
@@ -11010,6 +10805,19 @@ packages:
 
   /reselect@5.2.0:
     resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+    dev: false
+
+  /resend@6.17.2:
+    resolution: {integrity: sha512-hbaXEORFIFfT2Bh03NsA/akTTTKkD1hiuJ88ke64c5dWVV6DyoLxzFve3OiZqVOQ+JKLJ5uVkPR6hlUslpJFoA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+    dependencies:
+      postal-mime: 2.7.4
+      standardwebhooks: 1.0.0
     dev: false
 
   /resolve-cwd@3.0.0:
@@ -11578,17 +11386,7 @@ packages:
   /smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  /socks-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==}
-    engines: {node: '>= 6'}
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-      socks: 2.8.9
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
+    dev: true
 
   /socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
@@ -11607,6 +11405,7 @@ packages:
     dependencies:
       ip-address: 10.2.0
       smart-buffer: 4.2.0
+    dev: true
 
   /source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -11661,6 +11460,13 @@ packages:
   /stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
+
+  /standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+    dev: false
 
   /statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -11828,10 +11634,6 @@ packages:
       es-object-atoms: 1.1.2
     dev: true
 
-  /string_decoder@0.10.31:
-    resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==}
-    dev: false
-
   /string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
     dependencies:
@@ -11927,39 +11729,6 @@ packages:
       '@babel/core': 7.29.7
       client-only: 0.0.1
       react: 18.3.1
-
-  /superagent-proxy@3.0.0(superagent@7.1.6):
-    resolution: {integrity: sha512-wAlRInOeDFyd9pyonrkJspdRAxdLrcsZ6aSnS+8+nu4x1aXbz6FWSTT9M6Ibze+eG60szlL7JA8wEIV7bPWuyQ==}
-    engines: {node: '>=6'}
-    peerDependencies:
-      superagent: '>= 0.15.4 || 1 || 2 || 3'
-    dependencies:
-      debug: 4.4.3
-      proxy-agent: 5.0.0
-      superagent: 7.1.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /superagent@7.1.6:
-    resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
-    engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
-    dependencies:
-      component-emitter: 1.3.1
-      cookiejar: 2.1.4
-      debug: 4.4.3
-      fast-safe-stringify: 2.1.1
-      form-data: 4.0.6
-      formidable: 2.1.5
-      methods: 1.1.2
-      mime: 2.6.0
-      qs: 6.15.3
-      readable-stream: 3.6.2
-      semver: 7.8.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /superstatic@10.0.0:
     resolution: {integrity: sha512-4xIenBdrIIYuqXrIVx/lejyCh4EJwEMPCwfk9VGFfRlhZcdvzTd3oVOUILrAGfC4pFUWixzPgaOVzAEZgeYI3w==}
@@ -12304,13 +12073,6 @@ packages:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
     dev: false
 
-  /type-check@0.3.2:
-    resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      prelude-ls: 1.1.2
-    dev: false
-
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -12463,11 +12225,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /universalify@0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
-    dev: false
 
   /universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -12736,15 +12493,6 @@ packages:
       - msw
     dev: true
 
-  /vm2@3.11.5:
-    resolution: {integrity: sha512-RSrkBiwrj6FRU+QdqNs6KG0XdlvJCjpQ4GXiqmMbrhmwfu5k/XIMpAer0L8f6iuf0uJ3a4T1xJN126Q8yf0VIA==}
-    engines: {node: '>=6.0'}
-    hasBin: true
-    dependencies:
-      acorn: 8.17.0
-      acorn-walk: 8.3.5
-    dev: false
-
   /void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -13008,6 +12756,7 @@ packages:
   /word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -13097,10 +12846,6 @@ packages:
   /xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
     dev: true
-
-  /xregexp@2.0.0:
-    resolution: {integrity: sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA==}
-    dev: false
 
   /xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}


### PR DESCRIPTION
- Add functions/lib/resend.js: lazy Resend client bound to Secret Manager RESEND_APIKEY, sendEmail() and addContact() helpers
- Add functions/lib/emailTemplates.js: simple inline-HTML templates for verify-email, welcome, discussion feedback, program deadline, and project invite emails, replacing Mailjet's hosted TemplateIDs
- Replace all getMailjet() call sites in functions/index.js (newUser, newProfile, newDiscussion, scheduledProgramEmailer, newProjectInvite) with sendEmail/addContact; new signups are auto-added to the Resend audience
- Swap node-mailjet for resend in functions/package.json and pnpm-lock.yaml
- Sending domain is noreply@sciteens.org (verified in Resend)

Out-of-band (not in this diff): created RESEND_APIKEY secret in Secret Manager with the same IAM binding as the old Mailjet secrets; created a single Resend audience and migrated 1049 contacts into it (Mailjet CSV export, excluding anyone who had previously unsubscribed, merged with Firebase Auth users not already in Mailjet or unsubscribed).