### PR TITLE
fix: surface failed project-upvote toggles and auto-deploy Firestore/…

### DIFF
--- a/cloud-build.yaml
+++ b/cloud-build.yaml
@@ -1,4 +1,23 @@
+# Rules deploy first: app code merged alongside a rules change must never
+# ship before the rules are live. Idempotent — a no-op if unchanged.
+# One-time setup: grant the Cloud Build service account
+# (<project-number>@cloudbuild.gserviceaccount.com) `roles/firebaserules.admin`
+# so it can push firestore.rules/storage.rules; firebase-tools picks up
+# that identity from the ambient Application Default Credentials.
+
 steps:
+  - name: 'gcr.io/cloud-builders/npm'
+    entrypoint: npx
+    args:
+      [
+        'firebase-tools@15.23.0',
+        'deploy',
+        '--only',
+        'firestore:rules,storage:rules',
+        '--project',
+        '${_NEXT_PUBLIC_FB_PROJECT_ID}',
+        '--non-interactive',
+      ]
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
     args:

--- a/components/ProjectUpvoteButton.js
+++ b/components/ProjectUpvoteButton.js
@@ -44,6 +44,10 @@ export default function ProjectUpvoteButton({
   // often pass a stale denormalized count after a local toggle.
   const [optimistic, setOptimistic] = useState(null)
   const [busy, setBusy] = useState(false)
+  // Set only when the transaction rejects (permission-denied, offline,
+  // contention) — surfaces the otherwise-silent optimistic revert so a
+  // failed vote doesn't just look like a random flicker.
+  const [error, setError] = useState(false)
 
   useEffect(() => {
     if (!optimistic) return
@@ -62,6 +66,14 @@ export default function ProjectUpvoteButton({
   useEffect(() => {
     if (!uid) setOptimistic(null)
   }, [uid])
+
+  // Auto-dismiss the failure ring so it doesn't linger indefinitely on a
+  // card the user has moved on from.
+  useEffect(() => {
+    if (!error) return undefined
+    const timer = setTimeout(() => setError(false), 4000)
+    return () => clearTimeout(timer)
+  }, [error])
 
   const upvoted = optimistic?.upvoted ?? serverUpvoted
   const displayCount =
@@ -89,6 +101,7 @@ export default function ProjectUpvoteButton({
       0,
       displayCount + (nextUpvoted ? 1 : -1)
     )
+    setError(false)
     setOptimistic({
       upvoted: nextUpvoted,
       upvote_count: nextCount,
@@ -104,6 +117,7 @@ export default function ProjectUpvoteButton({
     } catch (err) {
       console.error('toggleProjectUpvote failed:', err)
       setOptimistic(null)
+      setError(true)
     } finally {
       setBusy(false)
     }
@@ -112,44 +126,55 @@ export default function ProjectUpvoteButton({
   const label = upvoted
     ? t('projects.remove_support')
     : t('projects.support')
+  const title = error ? t('projects.support_failed') : label
 
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size={size === 'sm' ? 'sm' : 'default'}
-      onClick={handleClick}
-      disabled={busy}
-      aria-pressed={upvoted}
-      aria-label={label}
-      title={label}
-      className={cn(
-        'text-muted-foreground relative z-20 gap-1 tabular-nums',
-        upvoted && 'text-amber-500 hover:text-amber-500',
-        className
-      )}
-    >
-      <Zap
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size={size === 'sm' ? 'sm' : 'default'}
+        onClick={handleClick}
+        disabled={busy}
+        aria-pressed={upvoted}
+        aria-label={label}
+        aria-invalid={error}
+        title={title}
         className={cn(
-          'size-4 transition-colors',
-          size === 'sm' ? 'size-3.5' : 'size-4',
-          upvoted
-            ? 'fill-amber-400 text-amber-400'
-            : 'fill-none text-gray-300'
-        )}
-        aria-hidden="true"
-      />
-      <span
-        className={cn(
-          'min-w-[1ch] text-xs',
-          size === 'default' && 'text-sm',
-          upvoted
-            ? 'text-amber-500'
-            : 'text-muted-foreground'
+          'text-muted-foreground relative z-20 gap-1 tabular-nums',
+          upvoted && 'text-amber-500 hover:text-amber-500',
+          className
         )}
       >
-        {displayCount}
+        <Zap
+          className={cn(
+            'size-4 transition-colors',
+            size === 'sm' ? 'size-3.5' : 'size-4',
+            upvoted
+              ? 'fill-amber-400 text-amber-400'
+              : 'fill-none text-gray-300'
+          )}
+          aria-hidden="true"
+        />
+        <span
+          className={cn(
+            'min-w-[1ch] text-xs',
+            size === 'default' && 'text-sm',
+            upvoted
+              ? 'text-amber-500'
+              : 'text-muted-foreground'
+          )}
+        >
+          {displayCount}
+        </span>
+      </Button>
+      <span
+        role="status"
+        aria-live="polite"
+        className="sr-only"
+      >
+        {error ? t('projects.support_failed') : null}
       </span>
-    </Button>
+    </>
   )
 }

--- a/components/ProjectUpvoteButton.test.js
+++ b/components/ProjectUpvoteButton.test.js
@@ -179,4 +179,31 @@ describe('ProjectUpvoteButton', () => {
     ).toHaveAttribute('aria-pressed', 'true')
     expect(screen.getByText('1')).toBeInTheDocument()
   })
+
+  it('reverts optimistic state and surfaces an error when the toggle fails', async () => {
+    toggleMock.mockRejectedValue(
+      new Error('permission-denied')
+    )
+    render(<ProjectUpvoteButton projectId="p1" count={0} />)
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'projects.support',
+      })
+    )
+    // Optimistic flip is immediate.
+    expect(
+      screen.getByRole('button', {
+        name: 'projects.remove_support',
+      })
+    ).toHaveAttribute('aria-pressed', 'true')
+
+    const btn = await screen.findByRole('button', {
+      name: 'projects.support',
+    })
+    expect(btn).toHaveAttribute('aria-pressed', 'false')
+    expect(btn).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'projects.support_failed'
+    )
+  })
 })

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -338,7 +338,8 @@
     "results_count": "{{count}} results",
     "load_more": "Load more projects",
     "support": "Support this project",
-    "remove_support": "Remove support"
+    "remove_support": "Remove support",
+    "support_failed": "Couldn't save your vote. Please try again."
   },
   "fields": {
     "all": "All",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -338,7 +338,8 @@
     "results_count": "{{count}} resultados",
     "load_more": "Cargar más proyectos",
     "support": "Apoyar este proyecto",
-    "remove_support": "Quitar apoyo"
+    "remove_support": "Quitar apoyo",
+    "support_failed": "No se pudo guardar tu voto. Inténtalo de nuevo."
   },
   "fields": {
     "all": "Todos",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -338,7 +338,8 @@
     "results_count": "{{count}} résultats",
     "load_more": "Charger plus de projets",
     "support": "Soutenir ce projet",
-    "remove_support": "Retirer le soutien"
+    "remove_support": "Retirer le soutien",
+    "support_failed": "Impossible d'enregistrer votre vote. Veuillez réessayer."
   },
   "fields": {
     "all": "Tout",

--- a/public/locales/hi/common.json
+++ b/public/locales/hi/common.json
@@ -338,7 +338,8 @@
     "results_count": "{{count}} परिणाम",
     "load_more": "और परियोजनाएं लोड करें",
     "support": "इस परियोजना का समर्थन करें",
-    "remove_support": "समर्थन हटाएं"
+    "remove_support": "समर्थन हटाएं",
+    "support_failed": "आपका वोट सहेज नहीं सका। कृपया पुनः प्रयास करें।"
   },
   "fields": {
     "all": "सभी",


### PR DESCRIPTION
…Storage rules

Diagnosis: the /projects/{id}/upvotes/{uid} rules and the upvote_count- only update branch (added in fbe88ff) were never deployed to production
- cloud-build.yaml only ships the Next.js app to Cloud Run, nothing deploys firestore.rules/storage.rules. Every vote transaction was hitting the stale, pre-upvote ruleset and failing PERMISSION_DENIED, which the client silently swallowed as an optimistic revert (upvote flashes true, then reverts).

- ProjectUpvoteButton: surface a failed toggle instead of silently reverting. aria-invalid + title + an sr-only aria-live region report the failure; auto-dismisses after 4s or on the next click attempt.
- Add projects.support_failed to all four locales.
- cloud-build.yaml: deploy firestore:rules,storage:rules as the first build step (idempotent) so rule changes can never again ship without the app that depends on them. Requires the Cloud Build service account to hold roles/firebaserules.admin (granted directly against the live project as part of this change; the live rules were also deployed out of band via the Firebase Rules API so the fix is live immediately).