### PR TITLE
fix: add security.txt for vulnerability disclosure

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:support@sciteens.com
+Contact: mailto:john@sciteens.com
+Expires: 2027-07-25T00:00:00.000Z
+Preferred-Languages: en, es, fr, hi
+Canonical: https://sciteens.org/.well-known/security.txt


### PR DESCRIPTION
Cloudflare Security Insights flagged Security.txt as unconfigured. The zone is DNS-only (required for Firebase Hosting's managed SSL), so Cloudflare's edge-injected Security.txt feature never reaches traffic. Serve RFC 9116 security.txt directly from the app instead.