### PR TITLE
fix: point canonical/og:url and legacy links at sciteens.org

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -63,7 +63,7 @@ export default function Footer() {
                   </li>
                   <li>
                     <a
-                      href="mailto:info@sciteens.com"
+                      href="mailto:info@sciteens.org"
                       target="_blank"
                       rel="noreferrer"
                     >

--- a/components/SocialMeta.jsx
+++ b/components/SocialMeta.jsx
@@ -33,6 +33,7 @@ export default function SocialMeta({
       {keywords && (
         <meta name="keywords" content={keywords} />
       )}
+      {url && <link rel="canonical" href={url} />}
       {url && <meta property="og:url" content={url} />}
       <meta property="og:site_name" content="SciTeens" />
       <meta property="og:type" content={type} />

--- a/functions/index.js
+++ b/functions/index.js
@@ -364,7 +364,7 @@ exports.newProfile = functions
     const user = await admin.auth().getUser(id)
     const email = user.email
     const actionCodeSettings = {
-      url: 'https://sciteens.com/',
+      url: 'https://sciteens.org/',
       handleCodeInApp: false,
     }
     const verification_link = await admin
@@ -604,7 +604,7 @@ exports.newDiscussion = functions
             user.customClaims && user.customClaims['mentor']
               ? 'mentor'
               : 'student',
-          projectLink: `https://sciteens.com/project/${context.params.projectID}#${event.id}`,
+          projectLink: `https://sciteens.org/project/${context.params.projectID}#${event.id}`,
         }),
       })
     }
@@ -639,7 +639,7 @@ exports.scheduledProgramEmailer = functions
           // Send an email to each subscriber
           let subscribers = event.data().subscribers
           let link =
-            'https://sciteens.com/program/' + event.id
+            'https://sciteens.org/program/' + event.id
 
           subscribers.forEach((sub) => {
             // Fetch the user's email
@@ -712,7 +712,7 @@ exports.unsubscribe = functions
   })
   .https.onRequest(async (req, res) => {
     const allowedOrigins = [
-      'https://sciteens.com',
+      'https://sciteens.org',
       'http://localhost:3000',
     ]
     const origin = req.get('Origin')
@@ -1150,7 +1150,7 @@ exports.newProjectInvite = functions
         html: projectUpdateTemplate({
           projectName: title,
           projectLink:
-            'https://sciteens.com/project/' + event.id,
+            'https://sciteens.org/project/' + event.id,
         }),
       }).catch((err) => {
         console.log('resend error:' + err)

--- a/functions/lib/resend.js
+++ b/functions/lib/resend.js
@@ -31,7 +31,7 @@ const CONTACTS_AUDIENCE_ID =
   '8c384f39-b01c-4cc8-a97e-1c9660c85225'
 
 const FROM = 'SciTeens <noreply@sciteens.org>'
-const SITE_URL = 'https://sciteens.com'
+const SITE_URL = 'https://sciteens.org'
 // Firebase Functions v1 HTTPS triggers deploy to us-central1 by default
 // (no .region() call on any export in index.js) under the
 // directed-relic-266701 project (see .firebaserc). Update both if

--- a/lib/ogImage.js
+++ b/lib/ogImage.js
@@ -2,7 +2,7 @@
 // absolute URLs even when a page doesn't have request context handy;
 // override per-environment with NEXT_PUBLIC_SITE_URL if ever needed.
 export const SITE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL || 'https://sciteens.com'
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://sciteens.org'
 
 // Builds the absolute URL for the dynamically generated social card
 // served by pages/api/og.jsx. `eyebrow` drives the card's accent color

--- a/pages/api/og.jsx
+++ b/pages/api/og.jsx
@@ -235,7 +235,7 @@ export default async function handler(req, res) {
                       marginTop: 4,
                     }}
                   >
-                    sciteens.com
+                    sciteens.org
                   </div>
                 </div>
               </div>

--- a/pages/article/[slug].js
+++ b/pages/article/[slug].js
@@ -345,7 +345,7 @@ function Article({ article, recommendations }) {
                   <p className="text-foreground text-sm md:text-lg">
                     {t('article.submit_own')}{' '}
                     <a
-                      href="mailto:info@sciteens.com"
+                      href="mailto:info@sciteens.org"
                       target="_blank"
                       rel="noreferrer"
                       className="font-bold"

--- a/pages/educators.js
+++ b/pages/educators.js
@@ -54,7 +54,7 @@ export default function Educators() {
             {t('educators.contact_us')}
             <a
               target="_blank"
-              href="mailto:carlos@sciteens.com"
+              href="mailto:carlos@sciteens.org"
               className="text-sciteensLightGreen-regular hover:text-sciteensLightGreen-dark font-semibold"
               rel="noreferrer"
             >
@@ -65,7 +65,7 @@ export default function Educators() {
             &nbsp;
             <a
               target="_blank"
-              href="mailto:aarti@sciteens.com"
+              href="mailto:aarti@sciteens.org"
               className="text-sciteensLightGreen-regular hover:text-sciteensLightGreen-dark font-semibold"
               rel="noreferrer"
             >

--- a/pages/get-involved.js
+++ b/pages/get-involved.js
@@ -45,12 +45,12 @@ export default function GetInvolved() {
               <p className="mb-4 text-sm lg:text-base">
                 {t('get_involved.get_involved_student')}
                 <a
-                  href="mailto:opportunities@sciteens.com"
+                  href="mailto:opportunities@sciteens.org"
                   target="_blank"
                   className="text-sciteensGreen-regular hover:text-sciteensGreen-dark font-semibold"
                   rel="noreferrer"
                 >
-                  &nbsp;opportunities@sciteens.com.&nbsp;
+                  &nbsp;opportunities@sciteens.org.&nbsp;
                 </a>
               </p>
               <Link
@@ -78,16 +78,16 @@ export default function GetInvolved() {
               <p className="mb-4 text-sm lg:text-base">
                 {t('get_involved.get_involved_outreach')}
                 <a
-                  href="mailto:support@sciteens.com"
+                  href="mailto:support@sciteens.org"
                   target="_blank"
                   className="text-sciteensGreen-regular hover:text-sciteensGreen-dark font-semibold"
                   rel="noreferrer"
                 >
-                  &nbsp;opportunities@sciteens.com.&nbsp;
+                  &nbsp;opportunities@sciteens.org.&nbsp;
                 </a>
               </p>
               <a
-                href="mailto:support@sciteens.com"
+                href="mailto:support@sciteens.org"
                 target="_blank"
                 className="bg-sciteensLightGreen-regular hover:bg-sciteensLightGreen-dark rounded-lg p-2 text-center text-white shadow-md"
                 rel="noreferrer"
@@ -113,12 +113,12 @@ export default function GetInvolved() {
               <p className="mb-4 text-sm lg:text-base">
                 {t('get_involved.get_involved_funding')}
                 <a
-                  href="mailto:support@sciteens.com"
+                  href="mailto:support@sciteens.org"
                   target="_blank"
                   className="text-sciteensGreen-regular hover:text-sciteensGreen-dark font-semibold"
                   rel="noreferrer"
                 >
-                  &nbsp;opportunities@sciteens.com.&nbsp;
+                  &nbsp;opportunities@sciteens.org.&nbsp;
                 </a>
                 {t('get_involved.no_student_limited')}
               </p>

--- a/pages/legal/gdpr.js
+++ b/pages/legal/gdpr.js
@@ -97,7 +97,7 @@ export default function gdpr() {
               &quot;us&quot;, and &quot;our&quot;) uses
               cookies and similar technologies to recognize
               you when you visit our websites at
-              http://sciteens.com, (&quot;Websites&quot;).
+              http://sciteens.org, (&quot;Websites&quot;).
               It explains what these technologies are and
               why we use them, as well as your rights to
               control our use of them. In some cases we may
@@ -217,7 +217,7 @@ export default function gdpr() {
                 local storage, so we don&apos;t ask again on
                 every visit.
                 <br />
-                sciteens.com (first party, browser storage
+                sciteens.org (first party, browser storage
                 only; never sent to our servers)
                 <br />
                 Persists until you clear your browser data
@@ -369,7 +369,7 @@ export default function gdpr() {
               <p className="text-muted-foreground mb-4">
                 If you have any questions about our use of
                 cookies or other technologies, please email
-                us at support@sciteens.com or by post to:
+                us at support@sciteens.org or by post to:
               </p>
               <p className="text-sciteensGreen-regular my-4">
                 SciTeens Inc.

--- a/pages/legal/privacy.js
+++ b/pages/legal/privacy.js
@@ -168,8 +168,8 @@ export default function privacy() {
               have any questions or concerns about our
               policy, or our practices with regards to your
               personal information, please contact us at
-              support@sciteens.com. When you visit our
-              website https://sciteens.com, and use our
+              support@sciteens.org. When you visit our
+              website https://sciteens.org, and use our
               services, you trust us with your personal
               information. We take your privacy very
               seriously. In this privacy policy, we seek to
@@ -182,7 +182,7 @@ export default function privacy() {
               not agree with, please discontinue use of our
               Sites and our services. This privacy policy
               applies to all information collected through
-              our website (such as https://sciteens.com),
+              our website (such as https://sciteens.org),
               and/or any related services, sales, marketing
               or events (we refer to them collectively in
               this privacy policy as the
@@ -724,7 +724,7 @@ export default function privacy() {
                 http://ec.europa.eu/justice/data-protection/bodies/authorities/index_en.htm.
                 If you have questions or comments about your
                 privacy rights, you may email us at
-                support@sciteens.com.
+                support@sciteens.org.
               </p>
               <p className="mb-2 text-lg">
                 Account Information
@@ -911,7 +911,7 @@ export default function privacy() {
                 some circumstances. To request to review,
                 update, or delete your personal information,
                 please submit a request by emailing
-                support@sciteens.com. We will respond to
+                support@sciteens.org. We will respond to
                 your request within 30 days.
               </p>
             </div>
@@ -925,7 +925,7 @@ export default function privacy() {
                 If you have questions or comments about this
                 policy, you may contact our Data Protection
                 Officer (DPO), John Sutor, by email at
-                john@sciteens.com, or by post to:
+                john@sciteens.org, or by post to:
               </p>
               <p className="text-sciteensGreen-regular my-4">
                 SciTeens Inc.

--- a/pages/legal/terms.js
+++ b/pages/legal/terms.js
@@ -239,7 +239,7 @@ export default function terms() {
                 and SciTeens Inc., doing business as
                 SciTeens (&quot;SciTeens&quot;, “we”, “us”,
                 or “our”), concerning your access to and use
-                of the http://sciteens.com website as well
+                of the http://sciteens.org website as well
                 as any other media form, media channel,
                 mobile website or mobile application
                 related, linked, or otherwise connected
@@ -914,7 +914,7 @@ export default function terms() {
               <p className="text-muted-foreground mb-10">
                 We care about data privacy and security.
                 Please review our Privacy Policy:
-                https://sciteens.com/legal/privacy. By using
+                https://sciteens.org/legal/privacy. By using
                 the Site, you agree to be bound by our
                 Privacy Policy, which is incorporated into
                 these Terms of Use. Please be advised the


### PR DESCRIPTION
## What changed
- `lib/ogImage.js`: `SITE_URL` default fallback `https://sciteens.com` -> `https://sciteens.org`
- `components/SocialMeta.jsx`: added self-referencing `<link rel="canonical">` (was previously emitted nowhere)
- `pages/api/og.jsx`: generated social-card footer text `sciteens.com` -> `sciteens.org`
- `functions/lib/resend.js`: `SITE_URL` used in transactional/notification emails -> `sciteens.org`
- `functions/index.js`: 5 hardcoded `sciteens.com` URLs fixed (email verification link, project-feedback/invite links, program-deadline email link, and the `unsubscribe` endpoint's CORS `allowedOrigins`)
- `components/Footer.js`, `pages/article/[slug].js`, `pages/educators.js`, `pages/get-involved.js`, `pages/legal/{gdpr,privacy,terms}.js`: `mailto:` links and legal-copy domain references updated to `sciteens.org`, matching the already-migrated `noreply@sciteens.org` sender

## Why
`site:sciteens.org` returns 0 results - the domain was fully deindexed. Root cause: no page ever emitted a canonical tag, and `og:url`/`og:image` are built from `lib/ogImage.js`'s `SITE_URL`, which falls back to `sciteens.com` whenever `NEXT_PUBLIC_SITE_URL` is unset. Checked `cloud-build.yaml` - that build arg is never set, so production always hit the `.com` fallback. Every crawled page reinforced the old domain as canonical to Google and to social shares.

Also found and fixed a live functional bug along the way: the `unsubscribe` Cloud Function's CORS `allowedOrigins` only allowlisted `https://sciteens.com`, so the `/unsubscribe` page on the real `.org` site would have been silently CORS-blocked.

`sitemap.xml`, `robots.txt`, and `next-sitemap.js` already correctly reference `sciteens.org` and needed no changes.

## Validation
- `pnpm lint` - zero errors (only pre-existing, unrelated `react-hooks/exhaustive-deps` warnings)
- `pnpm test:unit` - 333/333 passing
- `node --check` on both edited Cloud Functions files
- Ad-hoc unit test confirmed `SITE_URL === 'https://sciteens.org'` and `getOgImageUrl()` builds against `.org` (removed after verifying)
- `grep` confirms no remaining `sciteens.com` references in application source

## Open questions/risks
- GSC manual-actions/security-issues check, sitemap resubmission, priority-URL indexing requests, and any backlink disavow are console actions outside this repo - do those once this deploys.
- Confirmed `@sciteens.org` mailbox migration only by the already-live `noreply@sciteens.org` FROM address and `sciteens.org`-branded email footer; if `support@`/`info@`/`carlos@`/`aarti@`/`opportunities@`/`john@` mailboxes don't yet exist on `.org`, those need to be provisioned to match.
