### PR TITLE
feat(search): improve project search relevance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,8 +100,17 @@ shadcn tokens.
   `functions/index.js`); `pages/api/search/projects.js` is the only thing
   that ever talks to Meilisearch — the client never sees `MEILI_HOST` or an
   API key. Plain browsing and single-topic filtering stay on Firestore
-  directly (see `lib/search.js#requiresSearchIndex`); only free-text search
-  and date-range filtering hit the index.
+  directly (see `lib/search.js#requiresSearchIndex`); free-text search,
+  date-range filtering and the "Most upvoted" ordering hit the index.
+  Relevance settings are split between
+  `scripts/lib/meilisearchIndexSettings.js` (index side: searchable
+  attributes, ranking rules, stop words, synonyms) and `lib/search.js`
+  (query side). Change them with numbers, not intuition:
+  `scripts/eval-meilisearch-relevance.js --baseline` scores both against the
+  fixture battery in `scripts/lib/relevanceBattery.js` and is documented in
+  `infra/meilisearch/README.md#relevance-tuning`. Changing what
+  `toSearchDocument` emits needs `scripts/reindex-meilisearch.js` to backfill
+  projects the triggers won't otherwise touch.
 - API routes (`pages/api/*`) are Next serverless functions, distinct from
   `functions/` (Firebase Cloud Functions). Keep server-only work (e.g. the
   Meilisearch admin/search keys) in API routes or `functions/`, never in

--- a/components/ProjectCard.js
+++ b/components/ProjectCard.js
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useTranslation } from 'next-i18next'
@@ -10,6 +10,7 @@ import {
 } from '../context/helpers'
 import { normalizeProject } from '../lib/projects'
 import { getDefaultProjectImage } from '../lib/defaultProjectImage'
+import { splitHighlightedText } from '../lib/search'
 import ProfilePhoto from './ProfilePhoto'
 import ProjectUpvoteButton from './ProjectUpvoteButton'
 
@@ -40,6 +41,26 @@ function fieldLimit(fields) {
     : 3
 }
 
+// Renders a Meilisearch `_formatted` value as text plus <mark>s. Projects
+// that didn't come from a search hit have no highlight, so this falls back
+// to the plain value and the card looks exactly as it always has.
+function Highlighted({ highlighted, plain }) {
+  const segments = splitHighlightedText(highlighted)
+  if (segments.length === 0) return plain
+  return segments.map((segment, index) =>
+    segment.match ? (
+      <mark
+        key={index}
+        className="bg-sciteensLightGreen-regular/25 text-foreground rounded-sm px-0.5"
+      >
+        {segment.text}
+      </mark>
+    ) : (
+      <Fragment key={index}>{segment.text}</Fragment>
+    )
+  )
+}
+
 export default function ProjectCard({
   project,
   date,
@@ -60,6 +81,9 @@ export default function ProjectCard({
   const translatedFields = getTranslatedFieldsDict(t)
   const hasPhoto =
     Boolean(normalizedProject?.project_photo) && !photoError
+  // `highlight.abstract` is derived from the same indexed field, so it is
+  // never present when the plain abstract is empty.
+  const hasAbstract = Boolean(normalizedProject.abstract)
 
   return (
     <Card className="border-border/60 hover:border-border hover:bg-muted/40 relative isolate overflow-hidden transition-colors">
@@ -163,11 +187,21 @@ export default function ProjectCard({
             </div>
           )}
           <h3 className="line-clamp-2 text-pretty text-base font-semibold md:text-lg lg:text-xl">
-            {normalizedProject.title}
+            <Highlighted
+              highlighted={
+                normalizedProject.highlight?.title
+              }
+              plain={normalizedProject.title}
+            />
           </h3>
-          {normalizedProject.abstract && (
+          {hasAbstract && (
             <p className="text-muted-foreground md:line-clamp-2 max-md:hidden mt-1.5 max-w-[68ch] text-sm leading-relaxed">
-              {normalizedProject.abstract}
+              <Highlighted
+                highlighted={
+                  normalizedProject.highlight?.abstract
+                }
+                plain={normalizedProject.abstract}
+              />
             </p>
           )}
           {fields.length > 0 && (

--- a/components/ProjectCard.test.js
+++ b/components/ProjectCard.test.js
@@ -6,6 +6,10 @@ import {
   screen,
 } from '@testing-library/react'
 import ProjectCard from './ProjectCard'
+import {
+  HIGHLIGHT_POST_TAG,
+  HIGHLIGHT_PRE_TAG,
+} from '../lib/search'
 
 // Regression guard for the zero-member "By" label bug (the render gate
 // is `member_arr?.length > 0`, not a truthy-empty-array check — an
@@ -199,5 +203,81 @@ describe('ProjectCard', () => {
     const img = container.querySelector('img')
     expect(img).not.toBeNull()
     expect(img.getAttribute('alt')).toBe('Photo Project')
+  })
+
+  it('renders a project with no highlights as plain text', () => {
+    const { container } = render(
+      <ProjectCard
+        project={{
+          id: 'p10',
+          title: 'Plain Project',
+          abstract: 'A plain abstract.',
+        }}
+      />
+    )
+
+    expect(container.querySelector('mark')).toBeNull()
+    expect(screen.getByText('Plain Project')).toBeTruthy()
+    expect(
+      screen.getByText('A plain abstract.')
+    ).toBeTruthy()
+  })
+
+  it('marks the matched terms of a search hit', () => {
+    const { container } = render(
+      <ProjectCard
+        project={{
+          id: 'p11',
+          title: 'DNA Origami',
+          abstract: 'A study of DNA folding in plants.',
+          highlight: {
+            title: `${HIGHLIGHT_PRE_TAG}DNA${HIGHLIGHT_POST_TAG} Origami`,
+            abstract: `A study of ${HIGHLIGHT_PRE_TAG}DNA${HIGHLIGHT_POST_TAG} folding…`,
+          },
+        }}
+      />
+    )
+
+    expect(
+      [...container.querySelectorAll('mark')].map(
+        (mark) => mark.textContent
+      )
+    ).toEqual(['DNA', 'DNA'])
+    // The sentinels are structure, never content: none may reach the DOM.
+    expect(container.textContent).not.toContain(
+      HIGHLIGHT_PRE_TAG
+    )
+    expect(container.textContent).not.toContain(
+      HIGHLIGHT_POST_TAG
+    )
+    expect(container.textContent).toContain(
+      'A study of DNA folding…'
+    )
+  })
+
+  // aria-label and alt text feed screen readers and image fallbacks, so
+  // they take the plain title even when a highlighted one exists.
+  it('keeps highlight markup out of aria-label and alt text', () => {
+    const { container } = render(
+      <ProjectCard
+        project={{
+          id: 'p12',
+          title: 'DNA Origami',
+          project_photo: 'https://example.com/photo.jpg',
+          highlight: {
+            title: `${HIGHLIGHT_PRE_TAG}DNA${HIGHLIGHT_POST_TAG} Origami`,
+          },
+        }}
+      />
+    )
+
+    expect(
+      container
+        .querySelector('a[aria-label]')
+        .getAttribute('aria-label')
+    ).toBe('DNA Origami')
+    expect(
+      container.querySelector('img').getAttribute('alt')
+    ).toBe('DNA Origami')
   })
 })

--- a/components/search/TopicsList.js
+++ b/components/search/TopicsList.js
@@ -7,6 +7,11 @@ import { cn } from '@/lib/utils'
 // sidebar/sheet on every page. `facets` is optional: pages backed by a
 // search index (projects) pass live counts, pages that aren't (courses,
 // articles) simply omit it and the counts don't render.
+//
+// Counts are scoped to the active search, and Meilisearch omits empty
+// buckets from a facet distribution, so a topic missing from a non-empty
+// `facets` means zero matches — rendered as "0" rather than left blank,
+// which would read as "unknown" next to siblings that do show a number.
 export default function TopicsList({
   topicsLabel,
   fields,
@@ -37,12 +42,12 @@ export default function TopicsList({
       <div className="flex flex-col gap-1">
         {Object.entries(fields).map(([key, value]) => {
           const count =
-            facets && key !== 'All'
+            facets?.length && key !== 'All'
               ? facets.find(
                   (facet) =>
                     facet.field.toLowerCase() ===
                     key.toLowerCase()
-                )?.count
+                )?.count ?? 0
               : undefined
           const active =
             key === 'All' ? !field : field === key

--- a/functions/search.js
+++ b/functions/search.js
@@ -74,6 +74,11 @@ function toSearchDocument(id, data) {
   const fields = Array.isArray(data.fields)
     ? data.fields
     : []
+  const memberArr = Array.isArray(data.member_arr)
+    ? data.member_arr
+    : Array.isArray(data.members)
+    ? data.members
+    : []
   return {
     id,
     title: data.title || data.name || '',
@@ -85,11 +90,21 @@ function toSearchDocument(id, data) {
         fields.map(normalizeField).filter(Boolean)
       ),
     ],
-    member_arr: Array.isArray(data.member_arr)
-      ? data.member_arr
-      : Array.isArray(data.members)
-      ? data.members
-      : [],
+    member_arr: memberArr,
+    // Flattened separately from member_arr so the searchable attribute
+    // can be just the names: indexing member_arr wholesale would also
+    // make uids and profile slugs match free-text queries.
+    member_names: [
+      ...new Set(
+        memberArr
+          .map((member) =>
+            typeof member?.display === 'string'
+              ? member.display.trim()
+              : ''
+          )
+          .filter(Boolean)
+      ),
+    ],
     date: toMillis(data.date),
     upvote_count:
       typeof data.upvote_count === 'number' &&
@@ -170,6 +185,7 @@ async function deleteProjectFromIndex(id) {
 }
 
 module.exports = {
+  CANONICAL_FIELDS,
   toSearchDocument,
   indexProject,
   deleteProjectFromIndex,

--- a/functions/search.test.js
+++ b/functions/search.test.js
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+const { toSearchDocument } = require('./search')
+
+describe('toSearchDocument', () => {
+  it('maps a project into the indexed shape', () => {
+    expect(
+      toSearchDocument('p1', {
+        title: 'DNA Origami',
+        abstract: 'A study of <b>DNA</b>&nbsp;folding.',
+        project_photo: 'https://example.com/p.jpg',
+        fields: ['Biology'],
+        member_arr: [
+          { uid: 'u1', display: 'Ada Lovelace' },
+        ],
+        date: '2024-03-11T00:00:00.000Z',
+        upvote_count: 7,
+      })
+    ).toEqual({
+      id: 'p1',
+      title: 'DNA Origami',
+      abstract: 'A study of DNA folding.',
+      project_photo: 'https://example.com/p.jpg',
+      fields: ['Biology'],
+      fields_facet: ['Biology'],
+      member_arr: [{ uid: 'u1', display: 'Ada Lovelace' }],
+      member_names: ['Ada Lovelace'],
+      date: 1710115200000,
+      upvote_count: 7,
+    })
+  })
+
+  // Without this attribute a search for a student or mentor's name returns
+  // nothing at all, since member_arr itself is not searchable.
+  it('flattens member display names, deduped and trimmed', () => {
+    expect(
+      toSearchDocument('p2', {
+        member_arr: [
+          { uid: 'u1', display: '  Ada Lovelace ' },
+          { uid: 'u2', display: 'Ada Lovelace' },
+          { uid: 'u3', display: 'Grace Hopper' },
+        ],
+      }).member_names
+    ).toEqual(['Ada Lovelace', 'Grace Hopper'])
+  })
+
+  // Legacy project docs predate the current member shape, so the mapper is
+  // fed entries that are not objects at all. A regression from `member?.display`
+  // to `member.display` throws on these.
+  it('skips members with no usable display name', () => {
+    expect(
+      toSearchDocument('p3', {
+        member_arr: [
+          { uid: 'u1' },
+          { uid: 'u2', display: '' },
+          { uid: 'u3', display: '   ' },
+          { uid: 'u4', display: 42 },
+          { uid: 'u5', display: {} },
+          null,
+          undefined,
+          'legacy-uid-string',
+          7,
+        ],
+      }).member_names
+    ).toEqual([])
+  })
+
+  // The refactor that introduced member_names hoisted this fallback out of
+  // the return object; a non-array member_arr must still reach `members`.
+  it('falls back to `members` when member_arr is not an array', () => {
+    expect(
+      toSearchDocument('p3b', {
+        member_arr: { u1: 'not an array' },
+        members: [{ uid: 'u1', display: 'Grace Hopper' }],
+      })
+    ).toMatchObject({
+      member_arr: [{ uid: 'u1', display: 'Grace Hopper' }],
+      member_names: ['Grace Hopper'],
+    })
+  })
+
+  it('reads member names off the legacy `members` key', () => {
+    expect(
+      toSearchDocument('p4', {
+        members: [{ uid: 'u1', display: 'Ada Lovelace' }],
+      }).member_names
+    ).toEqual(['Ada Lovelace'])
+  })
+
+  it('folds legacy lowercase fields into one facet bucket', () => {
+    const doc = toSearchDocument('p5', {
+      fields: ['biology', 'Biology', 'computer science'],
+    })
+    expect(doc.fields).toEqual([
+      'biology',
+      'Biology',
+      'computer science',
+    ])
+    expect(doc.fields_facet).toEqual([
+      'Biology',
+      'Computer Science',
+    ])
+  })
+})

--- a/infra/meilisearch/README.md
+++ b/infra/meilisearch/README.md
@@ -99,6 +99,78 @@ is also the intended place to mint a scoped, search-only API key (Meilisearch
 `POST /keys` with `actions: ["search"]`, `indexes: ["projects"]`) for
 client-side/read-only callers, separate from the all-powerful master key.
 
+**3. Backfill after an indexer change.** The Firestore triggers in
+`functions/index.js` only reach a project when it is written, so a change to
+`functions/search.js#toSearchDocument` leaves every untouched project on the
+old shape. `scripts/reindex-meilisearch.js` re-applies the index settings and
+re-pushes every project (dry run by default, `--execute` to write).
+
+## Relevance tuning
+
+Index-side relevance lives in `scripts/lib/meilisearchIndexSettings.js`; the
+query-side half (highlighting, the relevance floor, sort mapping) lives in
+`lib/search.js`. Neither is tuned by taste. Both are measured by
+`scripts/eval-meilisearch-relevance.js` against the fixture corpus and query
+battery in `scripts/lib/relevanceBattery.js`:
+
+```sh
+docker run --rm -p 7701:7700 -e MEILI_MASTER_KEY=devkey \
+  getmeili/meilisearch:v1.48.2
+MEILI_HOST=http://127.0.0.1:7701 MEILI_MASTER_KEY=devkey \
+  node scripts/eval-meilisearch-relevance.js --baseline
+```
+
+It writes only to a scratch `projects-relevance-eval` index, deletes it
+afterwards, and refuses to run against a host that looks deployed. `--baseline`
+adds a run under the pre-tuning settings so a change reads as a delta.
+
+| Configuration     | P@5   | Recall | MRR   |
+| ----------------- | ----- | ------ | ----- |
+| Original settings | 0.350 | 0.346  | 0.536 |
+| Current settings  | 0.871 | 0.857  | 1.000 |
+
+What the individual pieces bought:
+
+- **`member_names` searchable, ranked above `abstract`.** Author queries
+  returned nothing at all before, because `member_arr` was stored but never
+  searched. The position matters as much as the presence: `attributeRank`
+  reads `searchableAttributes` in order, so with names below `abstract` a
+  project that merely cites someone outranks the one they authored.
+- **Stop words.** "how does sleep affect performance" returned four "How
+  Does ..." titles and not the sleep project at all; function words were
+  outvoting the content words.
+- **Synonyms.** "CO2", "comp sci" and "AI" each returned zero or one hit.
+  Student abstracts spell terms out; searchers type the abbreviation.
+- **`upvote_count:desc` below `exactness`, above `wordPosition`.** Orders
+  equally-relevant hits by community rating rather than by the near-arbitrary
+  "matched nearer the start of the field" signal, without letting a popular
+  near-match outrank a literal one.
+- **`rankingScoreThreshold: 0.2`.** Trims the tail where a long query matched
+  one incidental word, plus typo-tolerant near-misses ("neural" reaching
+  "neutral pH"). No relevant hit lost.
+
+Scalar averages hide ordering bugs, so the battery also asserts two rank-1
+expectations against documents planted for them, and the script exits
+non-zero if either fails:
+
+- "Priya Raman" must return the project she authored, not the one citing her.
+- "robot" must return the exact match, not the more upvoted "Robotics" title.
+
+Rejected on the evidence, recorded so they are not retried:
+
+- **`matchingStrategy: "frequency"`** regressed P@5 to 0.746. It keeps the
+  rarest query term, so "water pollution" dropped "water" and returned a
+  light-pollution project.
+- **`rankingScoreThreshold` above 0.2** started costing recall (0.786 at 0.3,
+  0.714 at 0.4).
+- **`photovoltaic -> solar`**, the reverse of a synonym that is kept one-way.
+  It matched nothing the literal token had not already found and pulled
+  "solar wind" space-science projects into a query about panels.
+
+The corpus is synthetic and small, so treat the absolute numbers as a
+regression baseline rather than a forecast for production. Re-run the battery
+before changing any of this.
+
 ## Access control: network-reachable, application-layer-gated
 
 This module grants `roles/run.invoker` to `allUsers` on the Cloud Run

--- a/lib/search.js
+++ b/lib/search.js
@@ -2,9 +2,41 @@
 // hits back into the shape ProjectCard expects. Framework- and
 // network-free on purpose so it's unit-testable directly — the actual HTTP
 // call to Meilisearch lives in pages/api/search/projects.js.
+//
+// The index-side half of relevance (searchable attributes, ranking rules,
+// stop words, synonyms) lives in scripts/lib/meilisearchIndexSettings.js.
 import { normalizeProject } from './projects'
 
 export const PROJECTS_SEARCH_HITS_PER_PAGE = 12
+export const PROJECTS_SEARCH_INDEX = 'projects'
+
+// Floor on Meilisearch's normalized [0,1] relevance score. Without it the
+// tail of a multi-word search is documents that matched one incidental word,
+// plus typo-tolerant near-misses ("neural" reaching "neutral pH"). 0.2 was
+// the highest value that trimmed that tail without dropping a relevant hit
+// from the tuning battery; 0.3 started costing recall.
+export const RANKING_SCORE_THRESHOLD = 0.2
+
+// Meilisearch wraps matched terms in these. Deliberately control characters
+// rather than the default `<em>`: the formatted values pass through
+// lib/projects.js#normalizeProject (which strips HTML) and are rendered as
+// React text, never as markup, so a tag-shaped marker would either be
+// swallowed or would have to be trusted as HTML.
+export const HIGHLIGHT_PRE_TAG = '\u0002'
+export const HIGHLIGHT_POST_TAG = '\u0003'
+
+// Escaped and alternated rather than dropped into a character class, so this
+// stays correct if the sentinels ever change: `[<em></em>]` would strip every
+// `<`, `e`, `m`, `/` and `>` from plain text, and `]`/`-`/`\` would throw.
+const escapeRegExp = (value) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const HIGHLIGHT_TAGS = new RegExp(
+  `${escapeRegExp(HIGHLIGHT_PRE_TAG)}|${escapeRegExp(
+    HIGHLIGHT_POST_TAG
+  )}`,
+  'g'
+)
 
 function toMillis(value) {
   if (value === undefined || value === null || value === '')
@@ -42,17 +74,35 @@ export function buildProjectSearchFilter({
   return clauses.length ? clauses.join(' AND ') : undefined
 }
 
-// A request only needs Meilisearch at all once free-text search or a date
-// range is in play — plain field-only browsing stays on the existing
-// Firestore path (pages/projects.js), which needs no search infra.
+// A request only needs Meilisearch at all once free-text search, a date
+// range, or an upvote ordering is in play — plain field-only browsing stays
+// on the existing Firestore path (pages/projects.js), which needs no search
+// infra. Upvote ordering is here because the Firestore path would need a
+// composite (fields array-contains-any + upvote_count) index for it, while
+// the search index already sorts on upvote_count for free.
 export function requiresSearchIndex({
   search,
   dateFrom,
   dateTo,
+  sort,
 } = {}) {
   return Boolean(
-    (search && search.trim()) || dateFrom || dateTo
+    (search && search.trim()) ||
+      dateFrom ||
+      dateTo ||
+      sort === 'upvotes'
   )
+}
+
+function sortForQuery(sort, hasQueryText) {
+  if (sort === 'newest') return ['date:desc']
+  if (sort === 'oldest') return ['date:asc']
+  if (sort === 'upvotes')
+    return ['upvote_count:desc', 'date:desc']
+  // "Relevance" has nothing to rank by without query text, and Meilisearch
+  // then answers in internal document order — which reads as random. Date
+  // ordering is the only honest default for a filter-only browse.
+  return hasQueryText ? undefined : ['date:desc']
 }
 
 export function buildProjectSearchParams({
@@ -64,8 +114,9 @@ export function buildProjectSearchParams({
   page = 0,
   hitsPerPage = PROJECTS_SEARCH_HITS_PER_PAGE,
 } = {}) {
+  const q = search || ''
   const params = {
-    q: search || '',
+    q,
     limit: hitsPerPage,
     offset: page * hitsPerPage,
     filter: buildProjectSearchFilter({
@@ -73,13 +124,78 @@ export function buildProjectSearchParams({
       dateFrom,
       dateTo,
     }),
-    facets: ['fields_facet'],
     attributesToCrop: ['abstract'],
     cropLength: 40,
+    attributesToHighlight: ['title', 'abstract'],
+    highlightPreTag: HIGHLIGHT_PRE_TAG,
+    highlightPostTag: HIGHLIGHT_POST_TAG,
+    rankingScoreThreshold: RANKING_SCORE_THRESHOLD,
   }
-  if (sort === 'newest') params.sort = ['date:desc']
-  else if (sort === 'oldest') params.sort = ['date:asc']
+  const order = sortForQuery(sort, Boolean(q.trim()))
+  if (order) params.sort = order
   return params
+}
+
+// Two queries for one /multi-search round trip. The second exists only for
+// its facetDistribution and deliberately drops the `fields_facet` clause:
+// counted against the *filtered* hits, every topic but the selected one
+// reads 0, and counted against the whole index (what the sidebar used to
+// show) they describe a result set the visitor isn't looking at — click
+// "Environmental Science 9" on a search that has one environmental hit and
+// you get one result. Scoped to the query and dates but not the topic, the
+// counts finally say "of these results, N are Biology".
+export function buildProjectSearchQueries(options = {}) {
+  const hits = buildProjectSearchParams(options)
+  return [
+    { indexUid: PROJECTS_SEARCH_INDEX, ...hits },
+    {
+      indexUid: PROJECTS_SEARCH_INDEX,
+      q: hits.q,
+      limit: 0,
+      filter: buildProjectSearchFilter({
+        dateFrom: options.dateFrom,
+        dateTo: options.dateTo,
+      }),
+      facets: ['fields_facet'],
+      rankingScoreThreshold: RANKING_SCORE_THRESHOLD,
+    },
+  ]
+}
+
+// Splits a Meilisearch `_formatted` value into renderable runs. Callers map
+// this to text nodes and <mark>s; nothing here is ever handed to
+// dangerouslySetInnerHTML. Unbalanced or stray sentinels (a truncated crop,
+// a control character that somehow survived into project text) are dropped
+// rather than rendered.
+export function splitHighlightedText(value) {
+  if (typeof value !== 'string' || value === '') return []
+  const segments = []
+  // Stripped on both run kinds, not just plain ones: a literal sentinel in
+  // project text mis-anchors the scan, and the resulting match run would
+  // otherwise carry the raw control character into the DOM.
+  const push = (text, match) => {
+    const clean = text.replace(HIGHLIGHT_TAGS, '')
+    if (clean) segments.push({ text: clean, match })
+  }
+
+  let index = 0
+  for (;;) {
+    const open = value.indexOf(HIGHLIGHT_PRE_TAG, index)
+    if (open === -1) break
+    const close = value.indexOf(
+      HIGHLIGHT_POST_TAG,
+      open + HIGHLIGHT_PRE_TAG.length
+    )
+    if (close === -1) break
+    push(value.slice(index, open), false)
+    push(
+      value.slice(open + HIGHLIGHT_PRE_TAG.length, close),
+      true
+    )
+    index = close + HIGHLIGHT_POST_TAG.length
+  }
+  push(value.slice(index), false)
+  return segments
 }
 
 // Maps one Meilisearch hit into the same shape
@@ -90,12 +206,19 @@ export function mapSearchHitToProject(hit) {
   return normalizeProject({
     id: hit.id,
     title: hit.title,
-    abstract: hit._formatted?.abstract ?? hit.abstract,
+    abstract: hit.abstract,
     project_photo: hit.project_photo,
     fields: hit.fields,
     member_arr: hit.member_arr,
     date: hit.date,
     upvote_count: hit.upvote_count,
+    // Kept beside the plain values rather than replacing them: title and
+    // abstract still feed alt text, aria-labels and meta descriptions, none
+    // of which may carry highlight sentinels or a mid-sentence crop.
+    highlight: {
+      title: hit._formatted?.title ?? null,
+      abstract: hit._formatted?.abstract ?? null,
+    },
   })
 }
 

--- a/lib/search.test.js
+++ b/lib/search.test.js
@@ -1,11 +1,19 @@
 import { describe, expect, it } from 'vitest'
 import {
+  HIGHLIGHT_POST_TAG,
+  HIGHLIGHT_PRE_TAG,
+  RANKING_SCORE_THRESHOLD,
   buildProjectSearchFilter,
   buildProjectSearchParams,
+  buildProjectSearchQueries,
   formatFieldFacets,
   mapSearchHitToProject,
   requiresSearchIndex,
+  splitHighlightedText,
 } from './search'
+
+const mark = (text) =>
+  `${HIGHLIGHT_PRE_TAG}${text}${HIGHLIGHT_POST_TAG}`
 
 describe('buildProjectSearchFilter', () => {
   it('returns undefined with no constraints', () => {
@@ -93,6 +101,18 @@ describe('requiresSearchIndex', () => {
       requiresSearchIndex({ dateTo: '2024-01-01' })
     ).toBe(true)
   })
+
+  // Firestore would need a composite (fields array-contains-any +
+  // upvote_count) index to answer this; the search index already sorts on
+  // upvote_count.
+  it('is true for the upvote ordering, but not for date orderings', () => {
+    expect(requiresSearchIndex({ sort: 'upvotes' })).toBe(
+      true
+    )
+    expect(requiresSearchIndex({ sort: 'newest' })).toBe(
+      false
+    )
+  })
 })
 
 describe('buildProjectSearchParams', () => {
@@ -101,7 +121,6 @@ describe('buildProjectSearchParams', () => {
     expect(params.q).toBe('')
     expect(params.offset).toBe(0)
     expect(params.filter).toBeUndefined()
-    expect(params.facets).toEqual(['fields_facet'])
   })
 
   it('paginates via limit/offset', () => {
@@ -115,17 +134,200 @@ describe('buildProjectSearchParams', () => {
 
   it('maps sort=newest/oldest to a Meilisearch sort array', () => {
     expect(
-      buildProjectSearchParams({ sort: 'newest' }).sort
+      buildProjectSearchParams({
+        search: 'dna',
+        sort: 'newest',
+      }).sort
     ).toEqual(['date:desc'])
     expect(
-      buildProjectSearchParams({ sort: 'oldest' }).sort
+      buildProjectSearchParams({
+        search: 'dna',
+        sort: 'oldest',
+      }).sort
     ).toEqual(['date:asc'])
   })
 
-  it('omits sort for relevance (default)', () => {
+  it('breaks upvote ties by date so the ordering is total', () => {
+    expect(
+      buildProjectSearchParams({ sort: 'upvotes' }).sort
+    ).toEqual(['upvote_count:desc', 'date:desc'])
+  })
+
+  it('omits sort for relevance once there is query text', () => {
     expect(
       buildProjectSearchParams({ search: 'dna' }).sort
     ).toBeUndefined()
+  })
+
+  // Relevance cannot order an empty query, and Meilisearch then answers in
+  // internal document order — which looks random to someone who only
+  // picked a date range.
+  it('falls back to newest-first when there is no query text', () => {
+    expect(buildProjectSearchParams().sort).toEqual([
+      'date:desc',
+    ])
+    expect(
+      buildProjectSearchParams({ search: '   ' }).sort
+    ).toEqual(['date:desc'])
+  })
+
+  it('requests highlighting with non-HTML sentinels', () => {
+    const params = buildProjectSearchParams({
+      search: 'dna',
+    })
+    expect(params.attributesToHighlight).toEqual([
+      'title',
+      'abstract',
+    ])
+    expect(params.highlightPreTag).toBe(HIGHLIGHT_PRE_TAG)
+    expect(params.highlightPostTag).toBe(HIGHLIGHT_POST_TAG)
+    expect(/[<>]/.test(HIGHLIGHT_PRE_TAG)).toBe(false)
+    expect(/[<>]/.test(HIGHLIGHT_POST_TAG)).toBe(false)
+  })
+
+  it('applies the relevance floor', () => {
+    expect(
+      buildProjectSearchParams({ search: 'dna' })
+        .rankingScoreThreshold
+    ).toBe(RANKING_SCORE_THRESHOLD)
+  })
+})
+
+describe('buildProjectSearchQueries', () => {
+  it('pairs the hits query with a hit-free facet query', () => {
+    const [hits, facets] = buildProjectSearchQueries({
+      search: 'dna',
+    })
+    expect(hits.indexUid).toBe('projects')
+    expect(hits.limit).toBeGreaterThan(0)
+    expect(facets.indexUid).toBe('projects')
+    expect(facets.limit).toBe(0)
+    expect(facets.facets).toEqual(['fields_facet'])
+  })
+
+  // The whole point: counted against the topic-filtered hits, every other
+  // topic reads 0 and the sidebar becomes a dead end.
+  it('keeps the query and dates but drops the topic from the facet filter', () => {
+    const [hits, facets] = buildProjectSearchQueries({
+      search: 'dna',
+      field: 'Biology',
+      dateFrom: '2024-01-01',
+    })
+    expect(hits.filter).toContain(
+      'fields_facet = "Biology"'
+    )
+    expect(hits.filter).toContain('date >=')
+    expect(facets.q).toBe('dna')
+    expect(facets.filter).not.toContain('fields_facet')
+    expect(facets.filter).toContain('date >=')
+  })
+
+  it('scores the facet query on the same floor as the hits', () => {
+    const [, facets] = buildProjectSearchQueries({
+      search: 'dna',
+    })
+    expect(facets.rankingScoreThreshold).toBe(
+      RANKING_SCORE_THRESHOLD
+    )
+  })
+
+  // The facet query is built as a fresh literal, not spread from the hits
+  // query. The obvious refactor to `{ indexUid, ...hits, limit: 0 }` would
+  // pass every other test here while shipping a sort, an offset and crop
+  // work onto a query that returns no hits.
+  it('carries no hits-only parameters onto the facet query', () => {
+    const [, facets] = buildProjectSearchQueries({
+      search: 'dna',
+      sort: 'upvotes',
+      page: 2,
+    })
+    expect(facets.sort).toBeUndefined()
+    expect(facets.offset).toBeUndefined()
+    expect(facets.attributesToCrop).toBeUndefined()
+    expect(facets.attributesToHighlight).toBeUndefined()
+  })
+})
+
+describe('splitHighlightedText', () => {
+  it('returns nothing for a missing or empty value', () => {
+    expect(splitHighlightedText(undefined)).toEqual([])
+    expect(splitHighlightedText('')).toEqual([])
+    expect(splitHighlightedText(null)).toEqual([])
+  })
+
+  it('returns one plain run when nothing matched', () => {
+    expect(splitHighlightedText('no matches here')).toEqual(
+      [{ text: 'no matches here', match: false }]
+    )
+  })
+
+  it('splits marked terms out of the surrounding text', () => {
+    expect(
+      splitHighlightedText(
+        `A study of ${mark('DNA')} in ${mark('plants')}`
+      )
+    ).toEqual([
+      { text: 'A study of ', match: false },
+      { text: 'DNA', match: true },
+      { text: ' in ', match: false },
+      { text: 'plants', match: true },
+    ])
+  })
+
+  // A crop can cut the closing sentinel off. Rendering a stray control
+  // character is worse than losing the mark.
+  it('drops an unclosed sentinel instead of rendering it', () => {
+    expect(
+      splitHighlightedText(
+        `abstract ${HIGHLIGHT_PRE_TAG}DNA`
+      )
+    ).toEqual([{ text: 'abstract DNA', match: false }])
+  })
+
+  it('drops a stray closing sentinel with no opener', () => {
+    expect(
+      splitHighlightedText(`a${HIGHLIGHT_POST_TAG}b`)
+    ).toEqual([{ text: 'ab', match: false }])
+  })
+
+  it('recovers when a closing sentinel precedes an opening one', () => {
+    expect(
+      splitHighlightedText(
+        `a${HIGHLIGHT_POST_TAG}b${mark('c')}d`
+      )
+    ).toEqual([
+      { text: 'ab', match: false },
+      { text: 'c', match: true },
+      { text: 'd', match: false },
+    ])
+  })
+
+  it('emits no empty run for a zero-length match', () => {
+    expect(
+      splitHighlightedText(
+        `a${HIGHLIGHT_PRE_TAG}${HIGHLIGHT_POST_TAG}b`
+      )
+    ).toEqual([
+      { text: 'a', match: false },
+      { text: 'b', match: false },
+    ])
+    expect(
+      splitHighlightedText(
+        `${HIGHLIGHT_PRE_TAG}${HIGHLIGHT_POST_TAG}`
+      )
+    ).toEqual([])
+  })
+
+  // The invariant the whole sentinel scheme rests on: a control character
+  // that reached project text must never be rendered, and a literal one
+  // mis-anchors the scan so it can land inside a MATCH run, not just a
+  // plain one.
+  it('never returns a sentinel in any run, matched or not', () => {
+    const hostile = `A${HIGHLIGHT_PRE_TAG}B ${mark('DNA')}`
+    for (const segment of splitHighlightedText(hostile)) {
+      expect(segment.text).not.toContain(HIGHLIGHT_PRE_TAG)
+      expect(segment.text).not.toContain(HIGHLIGHT_POST_TAG)
+    }
   })
 })
 
@@ -155,14 +357,39 @@ describe('mapSearchHitToProject', () => {
     })
   })
 
-  it('prefers the cropped/highlighted abstract when present', () => {
+  // title/abstract feed alt text, aria-labels and meta descriptions, so the
+  // marked-up copies have to live somewhere else.
+  it('keeps highlights beside the plain title and abstract', () => {
     const project = mapSearchHitToProject({
       id: 'abc123',
       title: 'DNA Origami',
       abstract: 'Full abstract text goes on for a while.',
-      _formatted: { abstract: 'Full abstract…' },
+      _formatted: {
+        title: `${mark('DNA')} Origami`,
+        abstract: `Full ${mark('abstract')}…`,
+      },
     })
-    expect(project.abstract).toBe('Full abstract…')
+    expect(project.title).toBe('DNA Origami')
+    expect(project.abstract).toBe(
+      'Full abstract text goes on for a while.'
+    )
+    expect(project.highlight.title).toBe(
+      `${mark('DNA')} Origami`
+    )
+    expect(project.highlight.abstract).toBe(
+      `Full ${mark('abstract')}…`
+    )
+  })
+
+  it('nulls the highlights when Meilisearch returned none', () => {
+    const project = mapSearchHitToProject({
+      id: 'abc123',
+      title: 'DNA Origami',
+    })
+    expect(project.highlight).toEqual({
+      title: null,
+      abstract: null,
+    })
   })
 })
 

--- a/pages/api/search/projects.js
+++ b/pages/api/search/projects.js
@@ -8,7 +8,7 @@
 // but this server process (see infra/meilisearch/README.md's access
 // control section).
 import {
-  buildProjectSearchParams,
+  buildProjectSearchQueries,
   formatFieldFacets,
   mapSearchHitToProject,
 } from '@/lib/search'
@@ -26,7 +26,7 @@ function meiliHost() {
   return host ? host.replace(/\/+$/, '') : null
 }
 
-async function meiliSearch(params) {
+async function meiliMultiSearch(queries) {
   const host = meiliHost()
   if (!host) {
     throw Object.assign(
@@ -41,20 +41,17 @@ async function meiliSearch(params) {
     REQUEST_TIMEOUT_MS
   )
   try {
-    const res = await fetch(
-      `${host}/indexes/projects/search`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(searchKey && {
-            Authorization: `Bearer ${searchKey}`,
-          }),
-        },
-        body: JSON.stringify(params),
-        signal: controller.signal,
-      }
-    )
+    const res = await fetch(`${host}/multi-search`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(searchKey && {
+          Authorization: `Bearer ${searchKey}`,
+        }),
+      },
+      body: JSON.stringify({ queries }),
+      signal: controller.signal,
+    })
     if (!res.ok) {
       const text = await res.text().catch(() => '')
       throw Object.assign(
@@ -98,7 +95,7 @@ export default async function handler(req, res) {
 
   try {
     const pageParam = parsePageParam(firstParam(page))
-    const params = buildProjectSearchParams({
+    const queries = buildProjectSearchQueries({
       search: String(firstParam(q) ?? '').slice(
         0,
         MAX_QUERY_LENGTH
@@ -113,7 +110,8 @@ export default async function handler(req, res) {
       page: pageParam,
     })
 
-    const result = await meiliSearch(params)
+    const { results = [] } = await meiliMultiSearch(queries)
+    const [result = {}, facetResult = {}] = results
 
     res.setHeader('Cache-Control', 'private, no-store')
     res.status(200).json({
@@ -121,7 +119,9 @@ export default async function handler(req, res) {
         mapSearchHitToProject
       ),
       totalHits: result.estimatedTotalHits ?? 0,
-      facets: formatFieldFacets(result.facetDistribution),
+      facets: formatFieldFacets(
+        facetResult.facetDistribution
+      ),
       page: Math.floor(
         (result.offset ?? 0) / (result.limit || 1)
       ),

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -73,8 +73,8 @@ function mapProjectSnapshot(snapshot) {
   return projects
 }
 
-// Free-text search and/or a date range are answered by the self-hosted
-// Meilisearch index (pages/api/search/projects.js) — see
+// Free-text search, a date range, or upvote ordering are answered by the
+// self-hosted Meilisearch index (pages/api/search/projects.js) — see
 // lib/search.js#requiresSearchIndex. Plain browsing and single-topic
 // filtering stay on Firestore directly: it's already fast, needs no
 // search infra, and is what getStaticProps below seeds at build time.
@@ -119,7 +119,9 @@ async function fetchProjectsPage({
   sort,
   pageParam,
 }) {
-  if (requiresSearchIndex({ search, dateFrom, dateTo })) {
+  if (
+    requiresSearchIndex({ search, dateFrom, dateTo, sort })
+  ) {
     return fetchProjectsSearchPage({
       search,
       field,
@@ -171,9 +173,11 @@ async function fetchProjectsPage({
   }
 }
 
-// Independent of the listing query above: always asks Meilisearch for the
-// current facet counts (unfiltered) so the topic list can show live
-// numbers the moment the page loads, not just once a search is active.
+// Whole-index counts, used only when the listing itself came from
+// Firestore (plain browsing) and so carries no facet distribution of its
+// own. Once a search is active the page prefers the query-scoped counts
+// the API returns alongside the hits, which describe the result set on
+// screen rather than the entire index.
 // Failing silently (no counts shown) is the correct degrade — this must
 // never block or error the page.
 async function fetchProjectFacets() {
@@ -307,9 +311,11 @@ function Projects({ cached_projects }) {
   // understand: `?sort=anything` otherwise renders a blank Select
   // trigger and a chip that disagrees with the executed ordering.
   const rawSortParam = router.query?.sort || ''
-  const sortParam = ['newest', 'oldest'].includes(
-    rawSortParam
-  )
+  const sortParam = [
+    'newest',
+    'oldest',
+    'upvotes',
+  ].includes(rawSortParam)
     ? rawSortParam
     : ''
 
@@ -409,10 +415,29 @@ function Projects({ cached_projects }) {
   const facetsQuery = useQuery({
     queryKey: ['projectFacets'],
     queryFn: fetchProjectFacets,
+    // Only the Firestore browse path needs it. On a search the listing
+    // response already carries query-scoped counts, so firing this too would
+    // spend a second round trip (and possibly a cold start) on a
+    // distribution that is discarded a few lines below.
+    enabled:
+      router.isReady &&
+      !requiresSearchIndex({
+        search: searchParam,
+        dateFrom: dateFromParam,
+        dateTo: dateToParam,
+        sort: sortParam,
+      }),
     staleTime: 5 * 60 * 1000,
     retry: false,
   })
-  const facets = facetsQuery.data || []
+  // Query-scoped counts win whenever the listing came from the search
+  // index: "of these results, N are Biology" is the number that makes the
+  // topic list a usable next step. The whole-index counts only stand in
+  // for the Firestore browse path, which has no distribution to report.
+  const facets =
+    projectsQuery.data?.pages[0]?.facets ||
+    facetsQuery.data ||
+    []
 
   const projects = useMemo(
     () =>
@@ -508,6 +533,7 @@ function Projects({ cached_projects }) {
     relevance: t('projects.sort_relevance'),
     newest: t('projects.sort_newest'),
     oldest: t('projects.sort_oldest'),
+    upvotes: t('projects.sort_upvotes'),
   }
 
   const activeFilters = []
@@ -653,6 +679,9 @@ function Projects({ cached_projects }) {
               </SelectItem>
               <SelectItem value="oldest">
                 {t('projects.sort_oldest')}
+              </SelectItem>
+              <SelectItem value="upvotes">
+                {t('projects.sort_upvotes')}
               </SelectItem>
             </SelectContent>
           </Select>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -385,6 +385,7 @@
     "sort_relevance": "Relevance",
     "sort_newest": "Newest",
     "sort_oldest": "Oldest",
+    "sort_upvotes": "Most upvoted",
     "search_unavailable": "Search is temporarily unavailable, so no results could be loaded.",
     "results_count_one": "{{count}} result",
     "results_count_other": "{{count}} results",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -385,6 +385,7 @@
     "sort_relevance": "Relevancia",
     "sort_newest": "Más recientes",
     "sort_oldest": "Más antiguos",
+    "sort_upvotes": "Más votados",
     "search_unavailable": "La búsqueda no está disponible temporalmente, así que no se pudieron cargar resultados.",
     "results_count_one": "{{count}} resultado",
     "results_count_other": "{{count}} resultados",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -385,6 +385,7 @@
     "sort_relevance": "Pertinence",
     "sort_newest": "Plus récents",
     "sort_oldest": "Plus anciens",
+    "sort_upvotes": "Mieux notés",
     "search_unavailable": "La recherche est temporairement indisponible, aucun résultat n'a pu être chargé.",
     "results_count_one": "{{count}} résultat",
     "results_count_other": "{{count}} résultats",

--- a/public/locales/hi/common.json
+++ b/public/locales/hi/common.json
@@ -385,6 +385,7 @@
     "sort_relevance": "प्रासंगिकता",
     "sort_newest": "नवीनतम",
     "sort_oldest": "सबसे पुराने",
+    "sort_upvotes": "सर्वाधिक वोट किए गए",
     "search_unavailable": "खोज अस्थायी रूप से अनुपलब्ध है, इसलिए कोई परिणाम लोड नहीं हो सका।",
     "results_count_one": "{{count}} परिणाम",
     "results_count_other": "{{count}} परिणाम",

--- a/scripts/eval-meilisearch-relevance.js
+++ b/scripts/eval-meilisearch-relevance.js
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+// Measures search relevance against a throwaway Meilisearch index, so that a
+// change to scripts/lib/meilisearchIndexSettings.js or to the query shape in
+// lib/search.js can be justified with numbers instead of intuition. This is
+// the battery infra/meilisearch/README.md's "Relevance tuning" section refers
+// to; the table there is this script's output.
+//
+// Usage (against a local container, never production):
+//   docker run --rm -p 7701:7700 -e MEILI_MASTER_KEY=devkey \
+//     getmeili/meilisearch:v1.48.2
+//   MEILI_HOST=http://127.0.0.1:7701 MEILI_MASTER_KEY=devkey \
+//     node scripts/eval-meilisearch-relevance.js
+//
+//   --keep      leave the scratch index in place for manual querying
+//   --baseline  also run the pre-tuning settings and print both, so a change
+//               is reported as a delta rather than an absolute
+//
+// Safety: this writes to `projects-relevance-eval`, never to `projects`, and
+// deletes that index on the way out. It refuses to run against a host whose
+// name suggests production.
+'use strict'
+
+const {
+  PROJECTS_INDEX_SETTINGS,
+} = require('./lib/meilisearchIndexSettings')
+const {
+  CORPUS,
+  QUERIES,
+  RANK_ONE_EXPECTATIONS,
+  precisionAtK,
+  recall,
+  reciprocalRank,
+  summarize,
+} = require('./lib/relevanceBattery')
+const { toSearchDocument } = require('../functions/search')
+
+const INDEX = 'projects-relevance-eval'
+const HITS_PER_QUERY = 12
+
+// The settings this change replaced, kept only so --baseline can show the
+// delta. Do not "fix" these to match the current ones.
+const BASELINE_SETTINGS = {
+  searchableAttributes: ['title', 'abstract', 'fields'],
+  filterableAttributes: ['fields_facet', 'date'],
+  sortableAttributes: ['date'],
+  rankingRules: [
+    'words',
+    'typo',
+    'proximity',
+    'attribute',
+    'sort',
+    'exactness',
+  ],
+  stopWords: [],
+  synonyms: {},
+}
+
+function parseArgs(argv) {
+  const args = { keep: false, baseline: false }
+  for (const arg of argv) {
+    if (arg === '--keep') args.keep = true
+    else if (arg === '--baseline') args.baseline = true
+    else throw new Error(`Unknown argument: ${arg}`)
+  }
+  return args
+}
+
+function resolveHost() {
+  const host = (process.env.MEILI_HOST || '').replace(
+    /\/+$/,
+    ''
+  )
+  if (!host || !process.env.MEILI_MASTER_KEY) {
+    throw new Error(
+      'Usage: MEILI_HOST=<url> MEILI_MASTER_KEY=<key> node scripts/eval-meilisearch-relevance.js'
+    )
+  }
+  // This script creates, overwrites and deletes an index. Running it against
+  // the deployed instance would put a synthetic corpus next to real projects.
+  if (/run\.app|prod/i.test(host)) {
+    throw new Error(
+      `Refusing to run against what looks like a deployed host (${host}). Point MEILI_HOST at a local container.`
+    )
+  }
+  return host
+}
+
+function makeClient(host) {
+  const masterKey = process.env.MEILI_MASTER_KEY
+  return async function meili(
+    path,
+    { method = 'GET', body } = {}
+  ) {
+    const res = await fetch(`${host}${path}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${masterKey}`,
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    })
+    const text = await res.text()
+    if (!res.ok) {
+      throw new Error(
+        `${method} ${path} -> ${res.status}: ${text}`
+      )
+    }
+    return text ? JSON.parse(text) : null
+  }
+}
+
+async function settle(meili) {
+  for (let attempt = 0; attempt < 300; attempt++) {
+    const pending = await meili(
+      '/tasks?statuses=enqueued,processing&limit=1'
+    )
+    if (pending.results.length === 0) return
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  throw new Error('Meilisearch tasks did not settle')
+}
+
+async function runBattery(
+  meili,
+  { rankingScoreThreshold }
+) {
+  const rows = []
+  for (const { q, relevant } of QUERIES) {
+    const result = await meili(`/indexes/${INDEX}/search`, {
+      method: 'POST',
+      body: {
+        q,
+        limit: HITS_PER_QUERY,
+        rankingScoreThreshold,
+      },
+    })
+    const ids = result.hits.map((hit) => hit.id)
+    rows.push({
+      query: q,
+      hits: ids.length,
+      'P@5': Number(precisionAtK(ids, relevant).toFixed(2)),
+      recall: Number(recall(ids, relevant).toFixed(2)),
+      MRR: Number(reciprocalRank(ids, relevant).toFixed(2)),
+      top5: ids.slice(0, 5).join(' '),
+    })
+  }
+  return rows
+}
+
+async function checkRankOne(
+  meili,
+  { rankingScoreThreshold }
+) {
+  const results = []
+  for (const { q, expect, why } of RANK_ONE_EXPECTATIONS) {
+    const result = await meili(`/indexes/${INDEX}/search`, {
+      method: 'POST',
+      body: { q, limit: 3, rankingScoreThreshold },
+    })
+    const first = result.hits[0]?.id ?? null
+    results.push({
+      query: q,
+      expected: expect,
+      actual: first,
+      pass: first === expect,
+      why,
+    })
+  }
+  return results
+}
+
+async function evaluate(meili, label, settings) {
+  await meili(`/indexes/${INDEX}/settings`, {
+    method: 'PATCH',
+    body: settings,
+  })
+  await settle(meili)
+  // Only the tuned configuration is scored behind the relevance floor the
+  // app actually sends; the baseline never had one.
+  const rankingScoreThreshold =
+    settings === BASELINE_SETTINGS ? undefined : 0.2
+  const rows = await runBattery(meili, {
+    rankingScoreThreshold,
+  })
+  return {
+    label,
+    rows,
+    summary: summarize(rows),
+    rankOne: await checkRankOne(meili, {
+      rankingScoreThreshold,
+    }),
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const meili = makeClient(resolveHost())
+
+  await meili(`/indexes/${INDEX}`, {
+    method: 'DELETE',
+  }).catch(() => {})
+  await meili('/indexes', {
+    method: 'POST',
+    body: { uid: INDEX, primaryKey: 'id' },
+  })
+  // Indexed through the real mapper, so a toSearchDocument regression shows
+  // up here as a relevance drop rather than passing silently.
+  await meili(`/indexes/${INDEX}/documents`, {
+    method: 'POST',
+    body: CORPUS.map((project) =>
+      toSearchDocument(project.id, {
+        ...project,
+        member_arr: project.members.map((display, i) => ({
+          uid: `${project.id}-u${i}`,
+          display,
+          slug: display.toLowerCase().replace(/ /g, '-'),
+        })),
+      })
+    ),
+  })
+  await settle(meili)
+
+  const runs = []
+  if (args.baseline) {
+    runs.push(
+      await evaluate(meili, 'baseline', BASELINE_SETTINGS)
+    )
+  }
+  runs.push(
+    await evaluate(
+      meili,
+      'current',
+      PROJECTS_INDEX_SETTINGS
+    )
+  )
+
+  for (const run of runs) {
+    console.log(`\n=== ${run.label} ===`)
+    console.table(run.rows)
+    console.table([run.summary])
+    console.table(run.rankOne)
+  }
+
+  if (!args.keep) {
+    await meili(`/indexes/${INDEX}`, { method: 'DELETE' })
+  } else {
+    console.log(
+      `\nLeft index "${INDEX}" in place (--keep).`
+    )
+  }
+
+  const failures = runs
+    .at(-1)
+    .rankOne.filter((check) => !check.pass)
+  if (failures.length > 0) {
+    console.error(
+      `\n${failures.length} rank-1 expectation(s) failed:`
+    )
+    for (const failure of failures) {
+      console.error(
+        `  "${failure.query}": expected ${failure.expected}, got ${failure.actual} (${failure.why})`
+      )
+    }
+    process.exitCode = 1
+  }
+}
+
+main().catch((err) => {
+  console.error('eval-meilisearch-relevance failed:', err)
+  process.exit(1)
+})

--- a/scripts/lib/meilisearchIndexSettings.js
+++ b/scripts/lib/meilisearchIndexSettings.js
@@ -1,0 +1,186 @@
+// Relevance configuration for the Meilisearch `projects` index, shared by
+// scripts/setup-meilisearch.js (provision) and
+// scripts/reindex-meilisearch.js (backfill). Kept dependency-free so it can
+// be unit tested without reaching a Meilisearch instance.
+//
+// Every value here was picked against a measured query battery rather than
+// by taste. Re-measure before changing any of it:
+//   node scripts/eval-meilisearch-relevance.js --baseline
+// See the "Relevance tuning" section of infra/meilisearch/README.md for the
+// before/after numbers and for the changes that were tried and rejected.
+'use strict'
+
+// English function words only. Project titles on SciTeens are dominated by
+// them ("The Effect of X on Y", "How Does X Affect Y"), and because Meilisearch
+// strips stop words from the query too, leaving them in lets a query like
+// "how does sleep affect performance" rank every "How Does ..." title above
+// the one project actually about sleep. Content words are never listed here,
+// however common — "effect" and "study" still carry meaning in a search.
+const STOP_WORDS = [
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'but',
+  'by',
+  'can',
+  'did',
+  'do',
+  'does',
+  'for',
+  'from',
+  'had',
+  'has',
+  'have',
+  'how',
+  'i',
+  'if',
+  'in',
+  'into',
+  'is',
+  'it',
+  'its',
+  'my',
+  'of',
+  'on',
+  'or',
+  'our',
+  'over',
+  's',
+  'so',
+  'than',
+  'that',
+  'the',
+  'their',
+  'then',
+  'there',
+  'these',
+  'they',
+  'this',
+  'to',
+  'under',
+  'using',
+  'was',
+  'we',
+  'were',
+  'what',
+  'when',
+  'where',
+  'which',
+  'while',
+  'why',
+  'with',
+  'you',
+  'your',
+]
+
+// Abbreviation-to-expansion is one-way by design: a searcher types "cnn" and
+// wants the projects whose abstracts spell it out, but someone who typed the
+// full phrase already found them. Only the AI cluster and co2/carbon dioxide
+// are declared mutually, because in those the short form appears in project
+// text as often as the long one. `solar -> photovoltaic` is deliberately
+// one-way: the reverse found nothing the literal token had not already
+// matched, and dragged "solar wind" space-science projects into a query
+// about panels.
+//
+// Expansions are kept narrow. These were tried and removed for reaching into
+// unrelated topics: `dna -> genetic/genome` (matches "genetic algorithm" CS
+// projects), `robot -> autonomous` (matches autonomous-vehicle work with no
+// robotics in it), and `cv`/`ev` (collide with coefficient of variation and
+// the electron-volt).
+//
+// `renewable -> wind` looks like the same over-reach but measurably is not,
+// and the battery carries two adversarial documents (p34 "Solar Wind", p35
+// "Wind Tunnel") to keep it honest. Dropping it halves recall on the
+// renewable queries without improving precision: `matchingStrategy` defaults
+// to `last`, so "renewable energy solar wind" sheds "wind" from the tail
+// before it is ever matched, and only the expansion reaches the actual wind
+// turbine project. Precision is 0.5 either way, because the solar-wind false
+// positive arrives through `solar`, not through `wind`.
+const SYNONYMS = {
+  ai: ['artificial intelligence', 'machine learning'],
+  'artificial intelligence': [
+    'ai',
+    'ml',
+    'machine learning',
+  ],
+  ml: ['machine learning', 'artificial intelligence'],
+  'machine learning': [
+    'ml',
+    'ai',
+    'deep learning',
+    'neural network',
+  ],
+  'deep learning': ['neural network', 'machine learning'],
+  'neural network': ['nn', 'deep learning'],
+  nn: ['neural network'],
+  cnn: ['convolutional neural network'],
+  nlp: ['natural language processing'],
+  cs: ['computer science'],
+  compsci: ['computer science'],
+  'comp sci': ['computer science'],
+  bio: ['biology'],
+  chem: ['chemistry'],
+  math: ['mathematics'],
+  maths: ['mathematics'],
+  stats: ['statistics'],
+  env: ['environmental'],
+  eco: ['ecology', 'ecological'],
+  co2: ['carbon dioxide'],
+  'carbon dioxide': ['co2'],
+  h2o: ['water'],
+  dna: ['deoxyribonucleic acid', 'gene'],
+  rna: ['ribonucleic acid'],
+  pv: ['photovoltaic', 'solar panel'],
+  solar: ['photovoltaic'],
+  renewable: ['solar', 'photovoltaic', 'wind'],
+  covid: ['coronavirus', 'sars-cov-2', 'covid-19'],
+  ecg: ['electrocardiogram'],
+  eeg: ['electroencephalogram'],
+  robot: ['robotic', 'robotics'],
+}
+
+const PROJECTS_INDEX_SETTINGS = {
+  // Order IS the `attributeRank` priority order, lowest index wins. Names sit
+  // above `abstract` so a project someone authored outranks one that merely
+  // cites them in its body text.
+  searchableAttributes: [
+    'title',
+    'member_names',
+    'abstract',
+    'fields',
+  ],
+  filterableAttributes: ['fields_facet', 'date'],
+  // `upvote_count` is sortable for the "Most upvoted" listing option, on top
+  // of its role as the ranking tiebreaker below.
+  sortableAttributes: ['date', 'upvote_count'],
+  // `attribute` (the older combined rule) is deliberately split into
+  // `attributeRank` + `wordPosition` so `upvote_count:desc` can sit between
+  // them: which attribute matched still dominates, but among hits that are
+  // equally relevant the community-rated ones come first, instead of the
+  // near-meaningless "matched nearer the start of the field" signal.
+  // `exactness` deliberately stays ABOVE popularity: it is what keeps a
+  // literal term ahead of a synonym expansion, so an upvoted near-match must
+  // not be able to outrank an exact one.
+  rankingRules: [
+    'words',
+    'typo',
+    'proximity',
+    'sort',
+    'attributeRank',
+    'exactness',
+    'upvote_count:desc',
+    'wordPosition',
+  ],
+  stopWords: STOP_WORDS,
+  synonyms: SYNONYMS,
+}
+
+module.exports = {
+  PROJECTS_INDEX_SETTINGS,
+  STOP_WORDS,
+  SYNONYMS,
+}

--- a/scripts/lib/meilisearchIndexSettings.test.js
+++ b/scripts/lib/meilisearchIndexSettings.test.js
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest'
+
+const {
+  PROJECTS_INDEX_SETTINGS,
+  STOP_WORDS,
+  SYNONYMS,
+} = require('./meilisearchIndexSettings')
+const {
+  CANONICAL_FIELDS,
+  toSearchDocument,
+} = require('../../functions/search')
+
+// Every attribute named in the settings has to be one the indexer actually
+// emits. Meilisearch accepts a name that matches nothing without complaint,
+// so a typo here is a silent relevance regression, not an error.
+const INDEXED_ATTRIBUTES = Object.keys(
+  toSearchDocument('p1', {
+    title: 'T',
+    abstract: 'A',
+    fields: ['Biology'],
+    member_arr: [{ uid: 'u1', display: 'Ada' }],
+    date: '2024-01-01',
+    upvote_count: 1,
+  })
+)
+
+describe('projects index settings', () => {
+  it('only names attributes the indexer emits', () => {
+    const named = [
+      ...PROJECTS_INDEX_SETTINGS.searchableAttributes,
+      ...PROJECTS_INDEX_SETTINGS.filterableAttributes,
+      ...PROJECTS_INDEX_SETTINGS.sortableAttributes,
+      ...PROJECTS_INDEX_SETTINGS.rankingRules
+        .filter((rule) => rule.includes(':'))
+        .map((rule) => rule.split(':')[0]),
+    ]
+    expect(
+      named.filter(
+        (attribute) =>
+          !INDEXED_ATTRIBUTES.includes(attribute)
+      )
+    ).toEqual([])
+  })
+
+  // `attributeRank` reads this array's order, so a project someone authored
+  // must outrank one that merely names them in its abstract.
+  it('ranks member names above the abstract', () => {
+    const searchable =
+      PROJECTS_INDEX_SETTINGS.searchableAttributes
+    expect(searchable).toContain('member_names')
+    expect(searchable.indexOf('member_names')).toBeLessThan(
+      searchable.indexOf('abstract')
+    )
+  })
+
+  // Meilisearch rejects the whole settings PATCH if the combined `attribute`
+  // rule appears alongside either of the rules it was split into.
+  it('never mixes `attribute` with its split replacements', () => {
+    const rules = PROJECTS_INDEX_SETTINGS.rankingRules
+    expect(rules).not.toContain('attribute')
+    expect(rules).toContain('attributeRank')
+    expect(rules).toContain('wordPosition')
+  })
+
+  // Popularity decides only among hits that are already equally relevant.
+  // `exactness` stays above it, because that rule is what keeps a literal
+  // term ahead of a synonym expansion; below it, an upvoted near-match
+  // outranks an exact one.
+  it('breaks ties on upvotes, but never above exactness', () => {
+    const rules = PROJECTS_INDEX_SETTINGS.rankingRules
+    const upvotes = rules.indexOf('upvote_count:desc')
+    expect(upvotes).toBeGreaterThan(
+      rules.indexOf('attributeRank')
+    )
+    expect(upvotes).toBeGreaterThan(
+      rules.indexOf('exactness')
+    )
+    expect(upvotes).toBeLessThan(
+      rules.indexOf('wordPosition')
+    )
+  })
+
+  // Meilisearch documents a custom ranking rule over an attribute that is
+  // missing on some documents as undefined behaviour, and `toSearchDocument`
+  // emits `date: null` for a project with no or an unparseable date.
+  it('never ranks on an attribute the indexer can emit as null', () => {
+    const nullable = Object.entries(
+      toSearchDocument('p1', {})
+    )
+      .filter(([, value]) => value === null)
+      .map(([key]) => key)
+    const custom = PROJECTS_INDEX_SETTINGS.rankingRules
+      .filter((rule) => rule.includes(':'))
+      .map((rule) => rule.split(':')[0])
+    expect(
+      custom.filter((attribute) =>
+        nullable.includes(attribute)
+      )
+    ).toEqual([])
+  })
+
+  it('sorts on upvote_count so the listing can offer it', () => {
+    expect(
+      PROJECTS_INDEX_SETTINGS.sortableAttributes
+    ).toContain('upvote_count')
+  })
+
+  // Meilisearch lowercases tokens before matching, so a capitalised or
+  // duplicated entry is dead weight that never fires.
+  it('keeps stop words lowercase and unique', () => {
+    expect(STOP_WORDS).toEqual(
+      STOP_WORDS.map((word) => word.toLowerCase())
+    )
+    expect(new Set(STOP_WORDS).size).toBe(STOP_WORDS.length)
+  })
+
+  // Derived from real data rather than a hand-list, so it keeps biting as
+  // the vocabulary grows: a stop word is stripped from the query too, so any
+  // term the product itself treats as meaningful must not appear here.
+  it('never stops a word the product treats as meaningful', () => {
+    const meaningful = new Set([
+      ...CANONICAL_FIELDS.flatMap((field) =>
+        field.toLowerCase().split(' ')
+      ),
+      ...Object.keys(SYNONYMS).flatMap((key) =>
+        key.split(' ')
+      ),
+      ...Object.values(SYNONYMS).flatMap((expansions) =>
+        expansions.flatMap((expansion) =>
+          expansion.toLowerCase().split(' ')
+        )
+      ),
+    ])
+    expect(
+      STOP_WORDS.filter((word) => meaningful.has(word))
+    ).toEqual([])
+  })
+
+  // `member_names` is searchable, and stop words are stripped from documents
+  // as well as queries, so a stop word that is also a common given name
+  // makes that person unfindable by first name.
+  it('never stops a common given name', () => {
+    for (const name of [
+      'will',
+      'grace',
+      'mark',
+      'may',
+      'rose',
+      'art',
+      'sky',
+      'faith',
+    ]) {
+      expect(STOP_WORDS).not.toContain(name)
+    }
+  })
+
+  it('keeps synonym keys lowercase and non-empty', () => {
+    for (const [key, expansions] of Object.entries(
+      SYNONYMS
+    )) {
+      expect(key).toBe(key.toLowerCase())
+      expect(expansions.length).toBeGreaterThan(0)
+      expect(expansions).not.toContain(key)
+    }
+  })
+
+  // Expanding to a stop word would expand to nothing at all.
+  it('never expands a synonym into a stop word', () => {
+    for (const expansions of Object.values(SYNONYMS)) {
+      for (const expansion of expansions) {
+        for (const word of expansion.split(' ')) {
+          expect(STOP_WORDS).not.toContain(
+            word.toLowerCase()
+          )
+        }
+      }
+    }
+  })
+
+  // The comment above SYNONYMS claims exactly these pairs are mutual.
+  // Meilisearch synonyms are neither bidirectional nor transitive, so an
+  // unlisted reverse is silent one-way behaviour.
+  it('declares the pairs it calls mutual in both directions', () => {
+    for (const [left, right] of [
+      ['ai', 'artificial intelligence'],
+      ['ai', 'machine learning'],
+      ['ml', 'machine learning'],
+      ['ml', 'artificial intelligence'],
+      ['machine learning', 'deep learning'],
+      ['deep learning', 'neural network'],
+      ['co2', 'carbon dioxide'],
+    ]) {
+      expect(SYNONYMS[left]).toContain(right)
+      expect(SYNONYMS[right]).toContain(left)
+    }
+  })
+
+  // Not an oversight: the reverse was measured to add a "solar wind"
+  // space-science false positive while finding nothing the literal token
+  // did not already match.
+  it('keeps solar -> photovoltaic one-way', () => {
+    expect(SYNONYMS.solar).toContain('photovoltaic')
+    expect(SYNONYMS.photovoltaic).toBeUndefined()
+  })
+})

--- a/scripts/lib/relevanceBattery.js
+++ b/scripts/lib/relevanceBattery.js
@@ -1,0 +1,548 @@
+// Fixture corpus and query battery for scripts/eval-meilisearch-relevance.js,
+// plus the metric functions it reports. Kept dependency-free and separate from
+// the runner so the metrics can be unit tested without a Meilisearch instance.
+//
+// The corpus is synthetic but shaped like the real one: overlapping science
+// vocabulary, abbreviations spelled out in abstracts, repeated authors, and a
+// wide upvote spread. `relevant` on each query is a human judgement of what a
+// visitor typing that query wants back, written before any setting was tuned.
+// Some judgements are deliberately unreachable by lexical search (a "robot"
+// query cannot find a prosthetic-hand project that never says "robot"), which
+// is why the absolute numbers matter less than the delta between two runs.
+'use strict'
+
+const CORPUS = [
+  {
+    id: 'p01',
+    title:
+      'The Effect of Caffeine on the Heart Rate of Daphnia magna',
+    abstract:
+      'We measured how varying concentrations of caffeine change the cardiac rhythm of Daphnia magna. Heart rate was counted under a light microscope across five dose groups. Results show a dose dependent increase in beats per minute.',
+    fields: ['Biology'],
+    members: ['Ada Okafor', 'Liam Chen'],
+    upvote_count: 41,
+    date: '2024-03-11',
+  },
+  {
+    id: 'p02',
+    title:
+      'A Study of Artificial Intelligence Models for Early Skin Cancer Detection',
+    abstract:
+      'We trained a convolutional neural network on dermoscopy images to classify melanoma versus benign lesions. Transfer learning from ResNet reached 91 percent accuracy on a held out test set.',
+    fields: ['Computer Science', 'Medicine'],
+    members: ['Priya Raman'],
+    upvote_count: 128,
+    date: '2024-09-02',
+  },
+  {
+    id: 'p03',
+    title:
+      'Machine Learning Prediction of Air Quality Index in Urban Areas',
+    abstract:
+      'A gradient boosting model forecasts the air quality index using traffic density, humidity and temperature. We compare it against a linear baseline over two years of municipal sensor data.',
+    fields: ['Computer Science', 'Environmental Science'],
+    members: ['Diego Herrera'],
+    upvote_count: 33,
+    date: '2023-11-20',
+  },
+  {
+    id: 'p04',
+    title:
+      'Low Cost Water Filtration Using Activated Charcoal and Sand',
+    abstract:
+      'We built a gravity fed filter from activated charcoal, sand and gravel and tested removal of turbidity, lead and coliform bacteria from river water samples.',
+    fields: ['Environmental Science', 'Chemistry'],
+    members: ['Amara Diallo', 'Tom Becker'],
+    upvote_count: 57,
+    date: '2024-01-15',
+  },
+  {
+    id: 'p05',
+    title:
+      'Investigating Microplastic Concentration in Local Freshwater Streams',
+    abstract:
+      'Water samples from twelve stream sites were filtered and examined for microplastic particles. Concentration correlated strongly with proximity to storm drains.',
+    fields: ['Environmental Science'],
+    members: ['Nina Petrov'],
+    upvote_count: 22,
+    date: '2023-06-30',
+  },
+  {
+    id: 'p06',
+    title:
+      'How Does Soil pH Affect the Germination Rate of Radish Seeds',
+    abstract:
+      'Radish seeds were germinated in soils buffered from pH 4 to pH 9. Germination rate peaked near neutral pH and dropped sharply in acidic conditions.',
+    fields: ['Biology'],
+    members: ['Ada Okafor'],
+    upvote_count: 8,
+    date: '2022-04-02',
+  },
+  {
+    id: 'p07',
+    title:
+      'Deep Learning for Handwritten Digit Recognition on Low Power Devices',
+    abstract:
+      'We quantized a small neural network so it runs on a microcontroller. Accuracy loss was under two percent while inference energy dropped by an order of magnitude.',
+    fields: ['Computer Science', 'Electrical Engineering'],
+    members: ['Yusuf Karim'],
+    upvote_count: 64,
+    date: '2024-05-19',
+  },
+  {
+    id: 'p08',
+    title:
+      'Solar Panel Efficiency Under Varying Angles of Incidence',
+    abstract:
+      'A photovoltaic panel was mounted on an adjustable rig and output power recorded across tilt angles. Peak efficiency occurred within ten degrees of perpendicular.',
+    fields: ['Physics', 'Electrical Engineering'],
+    members: ['Grace Lin'],
+    upvote_count: 47,
+    date: '2023-08-08',
+  },
+  {
+    id: 'p09',
+    title:
+      'Building a Cost Effective Wind Turbine from Recycled Materials',
+    abstract:
+      'A vertical axis wind turbine built from PVC and aluminium cans generated measurable current at wind speeds above four meters per second.',
+    fields: [
+      'Mechanical Engineering',
+      'Environmental Science',
+    ],
+    members: ['Tom Becker'],
+    upvote_count: 19,
+    date: '2022-10-01',
+  },
+  {
+    id: 'p10',
+    title:
+      'CRISPR Cas9 Knockout of the Pigment Gene in Zebrafish Embryos',
+    abstract:
+      'Using guide RNA targeting a pigmentation gene we produced mosaic zebrafish embryos and scored the loss of melanophores under a stereo microscope.',
+    fields: ['Biology', 'Medicine'],
+    members: ['Priya Raman', 'Ada Okafor'],
+    upvote_count: 96,
+    date: '2024-07-22',
+  },
+  {
+    id: 'p11',
+    title:
+      'Antibacterial Properties of Honey Against Escherichia coli',
+    abstract:
+      'Disk diffusion assays compared manuka honey, clover honey and a control. Manuka produced the largest zone of inhibition against E. coli cultures.',
+    fields: ['Biology', 'Medicine'],
+    members: ['Sofia Marino'],
+    upvote_count: 30,
+    date: '2023-02-14',
+  },
+  {
+    id: 'p12',
+    title:
+      'The Effect of Music Tempo on Short Term Memory Recall',
+    abstract:
+      'Participants memorized word lists while listening to music at 60, 120 and 180 beats per minute. Recall accuracy declined at the highest tempo.',
+    fields: ['Cognitive Science'],
+    members: ['Liam Chen'],
+    upvote_count: 15,
+    date: '2023-05-05',
+  },
+  {
+    id: 'p13',
+    title:
+      'Do Video Games Improve Reaction Time in Adolescents',
+    abstract:
+      'We measured simple visual reaction time in regular gamers versus non gamers using a browser based test. Gamers responded significantly faster.',
+    fields: ['Cognitive Science'],
+    members: ['Marcus Webb'],
+    upvote_count: 26,
+    date: '2022-12-11',
+  },
+  {
+    id: 'p14',
+    title:
+      'Modeling the Spread of Infectious Disease with Differential Equations',
+    abstract:
+      'A SIR compartmental model was fit to reported case data. We explored how the basic reproduction number changes epidemic peak timing.',
+    fields: ['Mathematics', 'Medicine'],
+    members: ['Grace Lin', 'Diego Herrera'],
+    upvote_count: 38,
+    date: '2023-09-27',
+  },
+  {
+    id: 'p15',
+    title:
+      'Prime Gaps and the Distribution of Twin Primes Below Ten Million',
+    abstract:
+      'We implemented a segmented sieve and analysed the empirical distribution of gaps between consecutive primes against the Hardy Littlewood conjecture.',
+    fields: ['Mathematics'],
+    members: ['Yusuf Karim'],
+    upvote_count: 12,
+    date: '2022-07-19',
+  },
+  {
+    id: 'p16',
+    title:
+      'Measuring Light Pollution with a DIY Sky Quality Meter',
+    abstract:
+      'An Arduino and light sensor were used to log night sky brightness across urban and rural sites. Readings tracked closely with satellite estimates.',
+    fields: ['Space Science', 'Environmental Science'],
+    members: ['Nina Petrov', 'Marcus Webb'],
+    upvote_count: 44,
+    date: '2024-02-28',
+  },
+  {
+    id: 'p17',
+    title:
+      'Classifying Galaxy Morphology with a Convolutional Neural Network',
+    abstract:
+      'Sloan Digital Sky Survey cutouts were used to train a CNN that separates spiral, elliptical and irregular galaxies. The model matched volunteer classifications on most examples.',
+    fields: ['Space Science', 'Computer Science'],
+    members: ['Priya Raman'],
+    upvote_count: 71,
+    date: '2024-06-14',
+  },
+  {
+    id: 'p18',
+    title:
+      'Extracting DNA from Strawberries Using Household Materials',
+    abstract:
+      'A dish soap and salt lysis buffer plus cold ethanol precipitated visible DNA strands from mashed strawberries. Yield varied with ripeness.',
+    fields: ['Biology', 'Chemistry'],
+    members: ['Sofia Marino'],
+    upvote_count: 5,
+    date: '2021-11-03',
+  },
+  {
+    id: 'p19',
+    title:
+      'Electrochemical Analysis of Lemon Battery Voltage Output',
+    abstract:
+      'Zinc and copper electrodes in citrus fruit produced a small potential difference. We measured how electrode spacing and fruit acidity affect voltage.',
+    fields: ['Chemistry', 'Physics'],
+    members: ['Tom Becker'],
+    upvote_count: 9,
+    date: '2022-02-20',
+  },
+  {
+    id: 'p20',
+    title:
+      'Synthesis and Characterization of Bioplastic from Potato Starch',
+    abstract:
+      'Starch, glycerol and vinegar were combined to cast a biodegradable film. Tensile strength and degradation rate in soil were compared to polyethylene.',
+    fields: ['Chemistry', 'Environmental Science'],
+    members: ['Amara Diallo'],
+    upvote_count: 53,
+    date: '2024-04-09',
+  },
+  {
+    id: 'p21',
+    title:
+      'Natural Language Processing for Detecting Misinformation in Headlines',
+    abstract:
+      'A transformer model fine tuned on labelled news headlines flags likely misinformation. We analysed which linguistic cues drove the predictions.',
+    fields: ['Computer Science'],
+    members: ['Marcus Webb'],
+    upvote_count: 87,
+    date: '2024-08-30',
+  },
+  {
+    id: 'p22',
+    title:
+      'Thermal Conductivity of Common Insulation Materials',
+    abstract:
+      'We compared fiberglass, wool, foam and recycled denim by measuring temperature decay inside identical insulated boxes.',
+    fields: ['Physics', 'Mechanical Engineering'],
+    members: ['Grace Lin'],
+    upvote_count: 11,
+    date: '2023-01-25',
+  },
+  {
+    id: 'p23',
+    title:
+      'Carbon Dioxide Absorption by Common Aquatic Plants',
+    abstract:
+      'Elodea and duckweed were sealed in bright and dark chambers while dissolved carbon dioxide was tracked with a pH indicator over six hours.',
+    fields: ['Biology', 'Environmental Science'],
+    members: ['Sofia Marino'],
+    upvote_count: 24,
+    date: '2023-10-17',
+  },
+  {
+    id: 'p24',
+    title:
+      'Effects of Sleep Deprivation on Problem Solving Performance',
+    abstract:
+      'High school volunteers completed logic puzzles after normal and restricted sleep. Accuracy dropped and completion time rose after restriction.',
+    fields: ['Cognitive Science', 'Medicine'],
+    members: ['Liam Chen', 'Nina Petrov'],
+    upvote_count: 35,
+    date: '2024-10-05',
+  },
+  {
+    id: 'p25',
+    title:
+      'An Autonomous Line Following Robot Using Infrared Sensors',
+    abstract:
+      'We designed a differential drive robot with a PID controller that tracks a taped line. Tuning the derivative term removed oscillation on tight curves.',
+    fields: [
+      'Mechanical Engineering',
+      'Electrical Engineering',
+    ],
+    members: ['Yusuf Karim', 'Diego Herrera'],
+    upvote_count: 62,
+    date: '2024-11-11',
+  },
+  {
+    id: 'p26',
+    title:
+      'Seismic Wave Attenuation in Layered Sedimentary Models',
+    abstract:
+      'A tabletop model with sand and clay layers was struck to generate waves recorded by geophones. Amplitude decay differed sharply between layers.',
+    fields: ['Earth Science', 'Physics'],
+    members: ['Amara Diallo'],
+    upvote_count: 7,
+    date: '2022-05-30',
+  },
+  {
+    id: 'p27',
+    title:
+      'Predicting Coastal Erosion Rates from Satellite Imagery',
+    abstract:
+      'Landsat scenes across fifteen years were segmented to trace shoreline retreat. Erosion accelerated at sites without vegetation cover.',
+    fields: ['Earth Science', 'Environmental Science'],
+    members: ['Marcus Webb'],
+    upvote_count: 29,
+    date: '2024-01-30',
+  },
+  {
+    id: 'p28',
+    title:
+      'Comparing Vitamin C Content in Fresh and Packaged Orange Juice',
+    abstract:
+      'Iodine titration quantified ascorbic acid in six juice samples. Fresh squeezed juice retained substantially more vitamin C after three days.',
+    fields: ['Chemistry', 'Medicine'],
+    members: ['Sofia Marino', 'Ada Okafor'],
+    upvote_count: 18,
+    date: '2023-03-22',
+  },
+  {
+    id: 'p29',
+    title:
+      'A Reinforcement Learning Agent That Learns to Play Snake',
+    abstract:
+      'A deep Q network was trained in a custom game environment. Reward shaping around food distance produced the fastest convergence.',
+    fields: ['Computer Science'],
+    members: ['Yusuf Karim'],
+    upvote_count: 74,
+    date: '2024-12-01',
+  },
+  {
+    id: 'p30',
+    title:
+      'The Effect of Fertilizer Runoff on Algal Bloom Growth',
+    abstract:
+      'Nitrogen and phosphorus were added to pond water microcosms. Algal density increased fastest in the high phosphorus treatment.',
+    fields: ['Environmental Science', 'Biology'],
+    members: ['Nina Petrov'],
+    upvote_count: 21,
+    date: '2023-07-07',
+  },
+  {
+    id: 'p31',
+    title:
+      'Designing a Prosthetic Hand with 3D Printing and Servo Actuation',
+    abstract:
+      'A five digit prosthetic hand was printed in PLA and actuated by tendon cables. Grip force was measured across three finger designs.',
+    fields: ['Mechanical Engineering', 'Medicine'],
+    members: ['Diego Herrera'],
+    upvote_count: 110,
+    date: '2024-09-25',
+  },
+  // Adversarial pair for the `exactness` guard: a popular near-match whose
+  // title is a longer word, against an unpopular exact match. Any ranking
+  // rule order that lets popularity outrank exactness flips these.
+  {
+    id: 'p32',
+    title: 'Robotics Club Outreach in Rural Middle Schools',
+    abstract:
+      'A survey of student interest before and after a term of visiting workshops run by our robotics club.',
+    fields: ['Mechanical Engineering'],
+    members: ['Grace Lin'],
+    upvote_count: 120,
+    date: '2024-02-02',
+  },
+  // Adversarial pair for attribute ranking: an author's own project against a
+  // project that merely cites the same person in its abstract.
+  {
+    id: 'p33',
+    title: 'A History of Programmable Computing Machines',
+    abstract:
+      'A literature review of early mechanical computing, covering the analytical engine and the notes of Priya Raman on modern reimplementations.',
+    fields: ['Computer Science'],
+    members: ['Tom Becker'],
+    upvote_count: 90,
+    date: '2024-04-04',
+  },
+  // Adversarial pair for the `renewable -> wind` synonym: "wind" appears
+  // prominently in two projects that have nothing to do with renewable
+  // energy, so any expansion that over-reaches shows up as a precision loss
+  // on the renewable query rather than as an opinion in a code comment.
+  {
+    id: 'p34',
+    title:
+      'Solar Wind Impact on Satellite Communication Blackouts',
+    abstract:
+      'Geomagnetic storm indices were correlated with reported satellite link outages across one solar cycle.',
+    fields: ['Space Science'],
+    members: ['Nina Petrov'],
+    upvote_count: 40,
+    date: '2024-05-05',
+  },
+  {
+    id: 'p35',
+    title:
+      'Wind Tunnel Testing of Low Speed Airfoil Profiles',
+    abstract:
+      'Lift and drag coefficients were measured for four printed airfoils across angles of attack in a homemade wind tunnel.',
+    fields: ['Mechanical Engineering'],
+    members: ['Tom Becker'],
+    upvote_count: 35,
+    date: '2024-06-06',
+  },
+]
+
+const QUERIES = [
+  {
+    q: 'machine learning',
+    relevant: ['p03', 'p29', 'p02', 'p07', 'p17', 'p21'],
+  },
+  {
+    q: 'AI',
+    relevant: ['p02', 'p03', 'p07', 'p17', 'p21', 'p29'],
+  },
+  {
+    q: 'neural network',
+    relevant: ['p02', 'p07', 'p17', 'p29'],
+  },
+  {
+    q: 'the effect of caffeine on heart rate',
+    relevant: ['p01'],
+  },
+  {
+    q: 'water pollution',
+    relevant: ['p04', 'p05', 'p30', 'p27'],
+  },
+  { q: 'Priya Raman', relevant: ['p02', 'p10', 'p17'] },
+  {
+    q: 'Yusuf Karim',
+    relevant: ['p07', 'p15', 'p25', 'p29'],
+  },
+  { q: 'DNA', relevant: ['p18', 'p10'] },
+  { q: 'CO2', relevant: ['p23'] },
+  {
+    // p33 is a Computer Science project, so it belongs here on its own
+    // merits, independent of how any setting happens to rank it.
+    q: 'comp sci',
+    relevant: [
+      'p02',
+      'p03',
+      'p07',
+      'p17',
+      'p21',
+      'p29',
+      'p33',
+    ],
+  },
+  {
+    q: 'how does sleep affect performance',
+    relevant: ['p24'],
+  },
+  { q: 'maths', relevant: ['p14', 'p15'] },
+  {
+    q: 'renewable energy solar wind',
+    relevant: ['p08', 'p09'],
+  },
+  { q: 'robot', relevant: ['p25', 'p31'] },
+]
+
+// Rank-1 checks that a scalar average would hide. Each names the one document
+// that MUST come back first, and why the ordering is load-bearing.
+const RANK_ONE_EXPECTATIONS = [
+  {
+    q: 'Priya Raman',
+    expect: 'p02',
+    why: 'a project she authored must outrank one that only cites her in its abstract (p33)',
+  },
+  {
+    q: 'robot',
+    expect: 'p25',
+    why: 'the exact term must outrank a more popular near-match (p32 "Robotics")',
+  },
+]
+
+const PRECISION_AT = 5
+
+function precisionAtK(
+  returnedIds,
+  relevantIds,
+  k = PRECISION_AT
+) {
+  const relevant = new Set(relevantIds)
+  const top = returnedIds.slice(0, k)
+  // Normalised by the reachable ceiling, so a query with two relevant
+  // documents can still score 1.0 at k=5.
+  const ceiling = Math.max(
+    1,
+    Math.min(k, relevantIds.length)
+  )
+  return (
+    top.filter((id) => relevant.has(id)).length / ceiling
+  )
+}
+
+function recall(returnedIds, relevantIds) {
+  if (relevantIds.length === 0) return 0
+  const relevant = new Set(relevantIds)
+  return (
+    returnedIds.filter((id) => relevant.has(id)).length /
+    relevantIds.length
+  )
+}
+
+function reciprocalRank(returnedIds, relevantIds) {
+  const relevant = new Set(relevantIds)
+  const first = returnedIds.findIndex((id) =>
+    relevant.has(id)
+  )
+  return first === -1 ? 0 : 1 / (first + 1)
+}
+
+function summarize(rows) {
+  if (rows.length === 0) {
+    return { 'P@5': 0, recall: 0, MRR: 0 }
+  }
+  const mean = (key) =>
+    Number(
+      (
+        rows.reduce((total, row) => total + row[key], 0) /
+        rows.length
+      ).toFixed(3)
+    )
+  return {
+    'P@5': mean('P@5'),
+    recall: mean('recall'),
+    MRR: mean('MRR'),
+  }
+}
+
+module.exports = {
+  CORPUS,
+  QUERIES,
+  RANK_ONE_EXPECTATIONS,
+  PRECISION_AT,
+  precisionAtK,
+  recall,
+  reciprocalRank,
+  summarize,
+}

--- a/scripts/lib/relevanceBattery.test.js
+++ b/scripts/lib/relevanceBattery.test.js
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+
+const {
+  CORPUS,
+  QUERIES,
+  RANK_ONE_EXPECTATIONS,
+  precisionAtK,
+  recall,
+  reciprocalRank,
+  summarize,
+} = require('./relevanceBattery')
+
+// The metrics decide whether a relevance change ships, so a bug here would
+// quietly bless a regression. The fixture checks matter for the same reason:
+// a judgement naming a document that is not in the corpus caps the score
+// below 1.0 forever and looks like a search defect.
+describe('relevance metrics', () => {
+  it('scores a perfect top-5 as 1, normalised by the reachable ceiling', () => {
+    expect(precisionAtK(['a', 'b', 'c'], ['a', 'b'])).toBe(
+      1
+    )
+    expect(
+      precisionAtK(
+        ['a', 'b', 'c', 'd', 'e'],
+        ['a', 'b', 'c', 'd', 'e', 'f']
+      )
+    ).toBe(1)
+  })
+
+  it('ignores hits past k', () => {
+    expect(
+      precisionAtK(['x', 'x', 'x', 'x', 'x', 'a'], ['a'])
+    ).toBe(0)
+  })
+
+  it('measures recall over the whole returned list', () => {
+    expect(recall(['x', 'a'], ['a', 'b'])).toBe(0.5)
+    expect(recall([], ['a'])).toBe(0)
+    expect(recall(['a'], [])).toBe(0)
+  })
+
+  it('reports the reciprocal of the first relevant rank', () => {
+    expect(reciprocalRank(['a'], ['a'])).toBe(1)
+    expect(reciprocalRank(['x', 'x', 'a'], ['a'])).toBe(
+      1 / 3
+    )
+    expect(reciprocalRank(['x'], ['a'])).toBe(0)
+  })
+
+  it('averages to three decimals and survives an empty run', () => {
+    expect(
+      summarize([
+        { 'P@5': 1, recall: 1, MRR: 1 },
+        { 'P@5': 0, recall: 0.5, MRR: 0 },
+      ])
+    ).toEqual({ 'P@5': 0.5, recall: 0.75, MRR: 0.5 })
+    expect(summarize([])).toEqual({
+      'P@5': 0,
+      recall: 0,
+      MRR: 0,
+    })
+  })
+})
+
+describe('relevance fixtures', () => {
+  const ids = new Set(CORPUS.map((project) => project.id))
+
+  it('has a unique id per corpus document', () => {
+    expect(ids.size).toBe(CORPUS.length)
+  })
+
+  it('only judges documents that exist in the corpus', () => {
+    for (const { q, relevant } of QUERIES) {
+      expect(relevant.length).toBeGreaterThan(0)
+      for (const id of relevant) {
+        expect(
+          ids.has(id),
+          `query "${q}" judges unknown document ${id}`
+        ).toBe(true)
+      }
+    }
+  })
+
+  it('only expects rank-1 documents that exist and are judged relevant', () => {
+    for (const { q, expect: id } of RANK_ONE_EXPECTATIONS) {
+      const query = QUERIES.find((entry) => entry.q === q)
+      expect(
+        query,
+        `no battery query for "${q}"`
+      ).toBeDefined()
+      expect(ids.has(id)).toBe(true)
+      expect(query.relevant).toContain(id)
+    }
+  })
+
+  // Each adversarial document only earns its place if something in the
+  // corpus can be confused with it.
+  it('keeps the adversarial documents that pin the ranking rules', () => {
+    for (const id of ['p32', 'p33', 'p34', 'p35']) {
+      expect(ids.has(id)).toBe(true)
+    }
+  })
+})

--- a/scripts/reindex-meilisearch.js
+++ b/scripts/reindex-meilisearch.js
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+// Rebuilds the Meilisearch `projects` index from Firestore.
+//
+// The Firestore triggers in functions/index.js only reach a project when it
+// is written, so a change to functions/search.js#toSearchDocument leaves
+// every untouched project indexed under the old shape. That is not cosmetic:
+// `member_names` is what makes searching for a student's name return their
+// projects, and until this runs, only projects edited since the deploy have
+// it.
+//
+// Usage:
+//   MEILI_HOST=https://meilisearch-xxxx.a.run.app \
+//   MEILI_MASTER_KEY=<master key from Secret Manager> \
+//   node scripts/reindex-meilisearch.js [--execute] [--project <id>]
+//
+// Defaults to a dry run (reports what would be sent, writes nothing).
+// Re-applies the index settings first, then upserts every project: document
+// adds are upserts keyed on `id`, so re-running is safe.
+'use strict'
+
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { execFileSync } = require('node:child_process')
+
+const {
+  PROJECTS_INDEX_SETTINGS,
+} = require('./lib/meilisearchIndexSettings')
+const { toSearchDocument } = require('../functions/search')
+
+const BATCH_SIZE = 200
+
+function parseArgs(argv) {
+  const args = { execute: false, project: undefined }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--execute') {
+      args.execute = true
+    } else if (arg === '--project') {
+      const value = argv[++i]
+      // Without this, `--project --execute` silently consumes the flag as
+      // the project id and downgrades a write run to a dry run.
+      if (!value || value.startsWith('--')) {
+        throw new Error('--project requires a project id')
+      }
+      args.project = value
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+  return args
+}
+
+// Dependency-free .env.local loader — this script runs standalone (plain
+// `node`, not the Next build), and dotenv isn't a repo dependency.
+// Shell/CI env vars already set win over the file, matching dotenv.
+function loadEnvLocal(repoRoot) {
+  const envPath = path.join(repoRoot, '.env.local')
+  if (!fs.existsSync(envPath)) return
+  for (const rawLine of fs
+    .readFileSync(envPath, 'utf8')
+    .split('\n')) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+    const eq = line.indexOf('=')
+    if (eq === -1) continue
+    const key = line.slice(0, eq).trim()
+    let value = line.slice(eq + 1).trim()
+    const quoted =
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    if (quoted) value = value.slice(1, -1)
+    if (!(key in process.env)) process.env[key] = value
+  }
+}
+
+// Same credential ladder as the other operator scripts (see
+// scripts/migrate-profile-pii.js for the full rationale): real ADC first,
+// then a pre-fetched token, then re-shelling to the gcloud CLI so a long
+// scan refreshes naturally instead of caching an expiring token.
+function resolveCredential(admin) {
+  const adcEnv = process.env.GOOGLE_APPLICATION_CREDENTIALS
+  const adcDefaultPath = path.join(
+    os.homedir(),
+    '.config',
+    'gcloud',
+    'application_default_credentials.json'
+  )
+  if (
+    (adcEnv && fs.existsSync(adcEnv)) ||
+    fs.existsSync(adcDefaultPath)
+  ) {
+    return admin.credential.applicationDefault()
+  }
+
+  if (process.env.GCLOUD_ACCESS_TOKEN) {
+    console.log(
+      'No Application Default Credentials found — using the static GCLOUD_ACCESS_TOKEN env var.'
+    )
+    const token = process.env.GCLOUD_ACCESS_TOKEN
+    return {
+      getAccessToken: async () => ({
+        access_token: token,
+        expires_in: 3600,
+      }),
+    }
+  }
+
+  try {
+    execFileSync('gcloud', ['--version'], { stdio: 'pipe' })
+  } catch {
+    throw new Error(
+      'No Application Default Credentials found, and the gcloud CLI is not on PATH.\n' +
+        'Run `gcloud auth application-default login`, set GOOGLE_APPLICATION_CREDENTIALS ' +
+        'to a service account key, set GCLOUD_ACCESS_TOKEN to a pre-fetched token, or ' +
+        'install the gcloud CLI and run `gcloud auth login`.'
+    )
+  }
+  console.log(
+    'No Application Default Credentials found — falling back to ' +
+      '`gcloud auth print-access-token` (gcloud auth login).'
+  )
+  return {
+    getAccessToken: async () => {
+      const token = execFileSync(
+        'gcloud',
+        ['auth', 'print-access-token'],
+        { stdio: ['ignore', 'pipe', 'pipe'] }
+      )
+        .toString()
+        .trim()
+      return { access_token: token, expires_in: 3600 }
+    },
+  }
+}
+
+function makeMeiliClient(host, masterKey) {
+  return async function meili(
+    endpoint,
+    { method = 'GET', body } = {}
+  ) {
+    const res = await fetch(`${host}${endpoint}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${masterKey}`,
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    })
+    const text = await res.text()
+    if (!res.ok) {
+      throw new Error(
+        `${method} ${endpoint} -> ${res.status}: ${text}`
+      )
+    }
+    return text ? JSON.parse(text) : null
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  loadEnvLocal(path.resolve(__dirname, '..'))
+
+  const host = (process.env.MEILI_HOST || '').replace(
+    /\/+$/,
+    ''
+  )
+  const masterKey = process.env.MEILI_MASTER_KEY
+  if (!host || !masterKey) {
+    throw new Error(
+      'Usage: MEILI_HOST=<url> MEILI_MASTER_KEY=<key> node scripts/reindex-meilisearch.js [--execute]'
+    )
+  }
+
+  const projectId =
+    args.project || process.env.NEXT_PUBLIC_FB_PROJECT_ID
+  if (!projectId) {
+    throw new Error(
+      'No project id: pass --project <id> or set NEXT_PUBLIC_FB_PROJECT_ID (e.g. via .env.local).'
+    )
+  }
+
+  const meili = makeMeiliClient(host, masterKey)
+  const admin = require('firebase-admin')
+  admin.initializeApp({
+    credential: resolveCredential(admin),
+    projectId,
+  })
+  const db = admin.firestore()
+
+  const mode = args.execute ? '[EXECUTE]' : '[DRY RUN]'
+  console.log(`${mode} reindexing projects/ into ${host}`)
+
+  if (args.execute) {
+    await meili('/indexes/projects/settings', {
+      method: 'PATCH',
+      body: PROJECTS_INDEX_SETTINGS,
+    })
+    console.log('Re-applied index settings.')
+  }
+
+  let lastDoc
+  let scanned = 0
+  let sent = 0
+  let withMemberNames = 0
+  try {
+    for (;;) {
+      let query = db
+        .collection('projects')
+        .orderBy('__name__')
+        .limit(BATCH_SIZE)
+      if (lastDoc) query = query.startAfter(lastDoc)
+      const snap = await query.get()
+      if (snap.empty) break
+
+      const documents = snap.docs.map((doc) =>
+        toSearchDocument(doc.id, doc.data())
+      )
+      scanned += documents.length
+      withMemberNames += documents.filter(
+        (doc) => doc.member_names.length > 0
+      ).length
+
+      if (args.execute) {
+        await meili('/indexes/projects/documents', {
+          method: 'POST',
+          body: documents,
+        })
+        sent += documents.length
+      }
+
+      lastDoc = snap.docs[snap.docs.length - 1]
+      console.log(`  ${scanned} projects processed ...`)
+      if (snap.docs.length < BATCH_SIZE) break
+    }
+  } catch (err) {
+    // Without this the operator sees only the error and cannot tell whether
+    // the index is now half-migrated, which it is.
+    console.error(
+      `\nFailed after ${scanned} projects read and ${sent} upserted. ` +
+        'The index is partially migrated. Document adds are upserts keyed ' +
+        'on id, so re-running with --execute is safe and idempotent.'
+    )
+    throw err
+  }
+
+  console.log(
+    `\n${mode} done: ${scanned} projects read, ${sent} upserted, ` +
+      `${withMemberNames} carry at least one searchable member name.`
+  )
+  if (!args.execute) {
+    console.log('Re-run with --execute to write.')
+  } else {
+    console.log(
+      'Meilisearch indexes asynchronously — poll GET /tasks until the ' +
+        'documentAdditionOrUpdate tasks report "succeeded".'
+    )
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('reindex-meilisearch failed:', err)
+    process.exit(1)
+  })
+}
+
+module.exports = { parseArgs, loadEnvLocal }

--- a/scripts/setup-meilisearch.js
+++ b/scripts/setup-meilisearch.js
@@ -12,7 +12,15 @@
 // re-running only prints a *new* search key (Meilisearch does not let you
 // recover a key's plaintext after creation) — if you already have one
 // deployed, keep it and skip updating MEILI_SEARCH_KEY.
+//
+// Changing the settings below only affects how already-indexed documents are
+// searched. Adding a new *document* attribute (as `member_names` was) needs
+// scripts/reindex-meilisearch.js afterwards to backfill existing projects.
 'use strict'
+
+const {
+  PROJECTS_INDEX_SETTINGS,
+} = require('./lib/meilisearchIndexSettings')
 
 const host = (process.env.MEILI_HOST || '').replace(
   /\/+$/,
@@ -72,21 +80,7 @@ async function ensureIndex() {
 async function applySettings() {
   await meili('/indexes/projects/settings', {
     method: 'PATCH',
-    body: {
-      searchableAttributes: ['title', 'abstract', 'fields'],
-      filterableAttributes: ['fields_facet', 'date'],
-      sortableAttributes: ['date'],
-      // Rank an exact/near-exact title match above a loose abstract
-      // match, then fall back to Meilisearch's default relevance rules.
-      rankingRules: [
-        'words',
-        'typo',
-        'proximity',
-        'attribute',
-        'sort',
-        'exactness',
-      ],
-    },
+    body: PROJECTS_INDEX_SETTINGS,
   })
   console.log('Applied index settings.')
 }


### PR DESCRIPTION
## What changed

**Index side** — new `scripts/lib/meilisearchIndexSettings.js`, shared by the provisioning and reindex scripts:

- `functions/search.js#toSearchDocument` emits `member_names`, and `searchableAttributes` ranks it above `abstract`. `attributeRank` reads that array in order, so position is load-bearing: below `abstract`, a project that merely cites someone outranks the one they authored.
- English stop words and science abbreviation synonyms.
- The legacy combined `attribute` ranking rule split into `attributeRank` + `wordPosition`, with `upvote_count:desc` between `exactness` and `wordPosition`.
- `upvote_count` sortable, backing a new "Most upvoted" option.

**Query side** — `lib/search.js`, `pages/api/search/projects.js`:

- `/multi-search` pairs the hits query with a facet-only query that keeps the search text and dates but drops the topic filter.
- Match highlighting via control-character sentinels, split by `splitHighlightedText` and rendered as `<mark>` elements. Nothing reaches `dangerouslySetInnerHTML`; `title`/`abstract` stay plain for `alt`, `aria-label` and meta descriptions.
- `rankingScoreThreshold: 0.2`, and `date:desc` when there is no query text to rank by.

**Operational** — `scripts/reindex-meilisearch.js` backfills `member_names` onto projects the Firestore triggers will never revisit. This must run after deploy or author search stays dead for existing projects.

## Why

Not tuning: the previous behaviour was broken in specific ways.

| Query | Before |
| --- | --- |
| `Priya Raman` | 0 hits — `member_arr` indexed but not searchable |
| `CO2`, `comp sci` | 0 hits — no synonyms |
| `how does sleep affect performance` | 4 hits, the sleep project not among them |
| date-range browse | Meilisearch internal document order |

The sidebar also ran a separate unfiltered facet query, so searching "machine learning" advertised "Environmental Science 9" when that search has one environmental hit.

## Validation

`scripts/eval-meilisearch-relevance.js --baseline`, against `getmeili/meilisearch:v1.48.2`:

| Configuration | P@5 | Recall | MRR |
| --- | --- | --- | --- |
| Original settings | 0.350 | 0.346 | 0.536 |
| Current settings | 0.871 | 0.857 | 1.000 |

Scalar averages hide ordering bugs, so the battery also pins two rank-1 expectations against documents planted for them, and exits non-zero if either regresses:

- `Priya Raman` must return the project she authored, not the one citing her in its abstract.
- `robot` must return the exact match, not the 120-upvote "Robotics Club" title.

Tried and **rejected** on the numbers, recorded in `infra/meilisearch/README.md#relevance-tuning`: `matchingStrategy: "frequency"` (P@5 0.746 — keeps the rarest term, so "water pollution" dropped "water" and returned a light-pollution project), `rankingScoreThreshold` above 0.2 (costs recall), and `photovoltaic -> solar` (found nothing the literal token had not, and pulled "solar wind" astronomy into a query about panels).

Also run: `pnpm lint`, `pnpm format`, `pnpm test:unit` (442), `pnpm test:rules` (137), `pnpm build`, `playwright test --project=emulator` (28). End-to-end through the real API route against a live container with a scoped search-only key, and in a browser confirming marks render, sentinels never reach the DOM, and the facet query no longer fires on the search path.

## Open questions / risks

- **`scripts/reindex-meilisearch.js` must run after deploy.** It is the one step that is not automatic.
- Stop words and synonyms are English-only against a single index; the four UI locales share it. Non-English project text loses nothing it had, but a francophone chemistry project would collide with `or` (gold) if that list ever grows.
- The relevance floor and the fixture corpus are small-sample. Treat the numbers as a regression baseline, not a production forecast, and re-run the battery on real data before tightening anything.
- `sort=upvotes` routes through Meilisearch, so during an outage that one ordering fails while plain browsing still works. The existing error banner covers it.
