### PR TITLE
fix(nav): align mobile sheet account section with nav rows

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -21,6 +21,8 @@ import {
   UserPlus,
   Menu,
   CircleUserRound,
+  LogOut,
+  User,
 } from 'lucide-react'
 
 import {
@@ -82,6 +84,11 @@ const NAV_LINKS = [
     active: (p) => p.includes('donate'),
   },
 ]
+
+const mobileRowClass = (isActive = false) =>
+  `flex flex-row items-center gap-4 rounded-lg px-3 py-3 ${
+    isActive ? 'bg-muted underline' : ''
+  }`
 
 export default function NavBar() {
   const [showMobileNav, setShowMobileNav] = useState(false)
@@ -186,7 +193,6 @@ export default function NavBar() {
                           {signInCheckResult?.user
                             ?.photoURL ? (
                             <Image
-                              id="profile_photo"
                               src={
                                 signInCheckResult.user
                                   .photoURL
@@ -233,13 +239,13 @@ export default function NavBar() {
           </div>
           <SheetContent
             side="right"
-            className="text-foreground px-6 pt-16 text-lg"
+            className="text-foreground gap-0 px-4 pb-6 pt-16 text-lg"
             closeLabel={i18n.t('auth.close')}
           >
             <SheetTitle className="sr-only">
               {i18n.t('navigation.menu')}
             </SheetTitle>
-            <div className="flex flex-col">
+            <div className="flex flex-1 flex-col gap-1 overflow-y-auto">
               {NAV_LINKS.map(
                 ({ href, label, Icon, active }) => (
                   <SheetClose
@@ -247,13 +253,11 @@ export default function NavBar() {
                     render={
                       <Link
                         href={href}
-                        className={`mb-4 flex flex-row items-center rounded-lg px-6 py-3 ${
+                        className={mobileRowClass(
                           active(router.pathname)
-                            ? 'bg-muted underline'
-                            : ''
-                        }`}
+                        )}
                       >
-                        <Icon className="text-muted-foreground mr-4 h-6 w-6" />
+                        <Icon className="text-muted-foreground h-6 w-6 shrink-0" />
                         <span className="whitespace-nowrap">
                           {i18n.t(`navigation.${label}`)}
                         </span>
@@ -267,13 +271,11 @@ export default function NavBar() {
                   render={
                     <Link
                       href="/signup/student"
-                      className={`mb-4 flex flex-row items-center rounded-lg px-6 py-3 ${
+                      className={mobileRowClass(
                         router.pathname.includes('signup')
-                          ? 'bg-muted underline'
-                          : ''
-                      }`}
+                      )}
                     >
-                      <UserPlus className="text-muted-foreground mr-4 h-6 w-6" />
+                      <UserPlus className="text-muted-foreground h-6 w-6 shrink-0" />
                       <span className="whitespace-nowrap">
                         {i18n.t('navigation.sign_up')}
                       </span>
@@ -283,66 +285,61 @@ export default function NavBar() {
               )}
             </div>
             {signedIn && (
-              <>
-                <hr className="bg-border mx-auto w-[80%]" />
-                <div className="mx-8">
-                  <div className="mx-auto mb-2 mt-6 flex flex-row items-center">
-                    {signInCheckResult?.user?.photoURL ? (
-                      <span className="relative mr-6 block h-10 w-10 overflow-hidden rounded-full">
-                        <Image
-                          id="profile_photo"
-                          src={
-                            signInCheckResult.user.photoURL
-                          }
-                          alt=""
-                          fill
-                          sizes="40px"
-                          className="object-cover"
-                        />
-                      </span>
-                    ) : (
-                      <CircleUserRound className="text-muted-foreground mr-6 h-10 w-10" />
-                    )}
-                    <p className="my-auto text-xl">
-                      {signInCheckResult.user.displayName}
-                    </p>
-                  </div>
-                  <div className="ml-4 flex flex-col text-left">
-                    <SheetClose
-                      render={
-                        <Link
-                          href={profileHref}
-                          className="flex flex-row items-center"
-                        >
-                          <div
-                            className={`mr-6 h-auto w-0.5 ${
-                              router.pathname.includes(
-                                'profile'
-                              )
-                                ? 'bg-primary'
-                                : 'bg-muted-foreground/50'
-                            }`}
-                          />
-                          <span>
-                            {i18n.t('navigation.profile')}
-                          </span>
-                        </Link>
-                      }
-                    />
-                    <div className="bg-muted-foreground/50 h-2 w-0.5" />
-                    <div className="flex flex-row">
-                      <div className="bg-muted-foreground/50 mr-6 h-auto w-0.5" />
-                      <SheetClose
-                        render={
-                          <button onClick={handleSignOut}>
-                            {i18n.t('navigation.sign_out')}
-                          </button>
+              <div className="border-border/60 mt-4 flex shrink-0 flex-col gap-1 border-t pt-4">
+                <div className="flex flex-row items-center gap-4 px-3 py-2">
+                  {signInCheckResult?.user?.photoURL ? (
+                    <span className="relative block h-10 w-10 shrink-0 overflow-hidden rounded-full">
+                      <Image
+                        src={
+                          signInCheckResult.user.photoURL
                         }
+                        alt=""
+                        fill
+                        sizes="40px"
+                        className="object-cover"
                       />
-                    </div>
-                  </div>
+                    </span>
+                  ) : (
+                    <CircleUserRound className="text-muted-foreground h-10 w-10 shrink-0" />
+                  )}
+                  <p
+                    className="truncate text-lg font-medium"
+                    title={
+                      signInCheckResult.user.displayName
+                    }
+                  >
+                    {signInCheckResult.user.displayName}
+                  </p>
                 </div>
-              </>
+                <SheetClose
+                  render={
+                    <Link
+                      href={profileHref}
+                      className={mobileRowClass(
+                        router.pathname.includes('profile')
+                      )}
+                    >
+                      <User className="text-muted-foreground h-6 w-6 shrink-0" />
+                      <span className="whitespace-nowrap">
+                        {i18n.t('navigation.profile')}
+                      </span>
+                    </Link>
+                  }
+                />
+                <SheetClose
+                  render={
+                    <button
+                      onClick={handleSignOut}
+                      className={`${mobileRowClass()} text-left`}
+                    >
+                      <LogOut className="text-muted-foreground h-6 w-6 shrink-0" />
+                      <span className="whitespace-nowrap">
+                        {i18n.t('navigation.sign_out')}
+                      </span>
+                    </button>
+                  }
+                />
+              </div>
             )}
           </SheetContent>
         </Sheet>


### PR DESCRIPTION
## What changed

`components/NavBar.js`, mobile hamburger `Sheet` only. The desktop nav and its avatar dropdown are untouched.

- New module-level `mobileRowClass(isActive = false)`. Every row in the sheet (nav links, Sign Up, Profile, Sign Out) now shares one shape: `flex items-center gap-4 rounded-lg px-3 py-3`, active state `bg-muted underline`. Row icons gained `shrink-0` and lost `mr-4`, since `gap-4` handles the spacing.
- Deleted the signed-in block's rail markup: the `<hr className="bg-border mx-auto w-[80%]">`, the `mx-8`/`ml-4` offsets, and the three `w-0.5` vertical connector divs.
- The account block is now `border-t border-border/60 pt-4 shrink-0`, containing an identity row (avatar plus `truncate` display name with a `title`), then Profile and Sign Out as ordinary rows. Sign Out uses the new `LogOut` glyph, Profile uses `User`.
- The link list is `flex-1 overflow-y-auto`; `SheetContent` is now `gap-0 px-4 pb-6` (was `px-6`, no bottom padding, relying on the popup's `gap-4` plus a per-row `mb-4`).
- Dropped `id="profile_photo"` from both the desktop dropdown avatar and the sheet avatar. `grep` finds no CSS selector, test, or script referencing it, and both elements were in the DOM simultaneously for a signed-in user with a photo (the desktop cluster is hidden with `lg:flex`, not unmounted), so the id was duplicated as well as dead.

## Why

The bottom of the sheet used a different visual language from the rows above it: indentation rails, an 80%-wide rule, and doubled horizontal padding. Profile and Sign Out read as misaligned orphans instead of menu items. The `hr` also carried `bg-border` with no border color, so it rendered as a stray hairline rather than the intended separator.

Separately, rows were `mb-4`-spaced inside a container with no scroll, so on a short viewport a signed-in user could push the account block off-screen with no way to reach Sign Out.

## Validation

- `pnpm lint` clean for `NavBar.js` (only pre-existing warnings elsewhere), `pnpm format` clean, `pnpm test:unit` 442 passed across 32 files, `pnpm build` green.
- `e2e/nav-a11y.spec.js` passes (focus trap, Escape-to-close, focus restoration).
- Throwaway Playwright spec against the emulator project, since removed: seeded a student with a deliberately long 36-character display name, signed in through the UI, opened the sheet at 390x844, then resized to 844x390 landscape to exercise the new scroll path. Asserted from the live DOM that the popup does not overflow, the link list does scroll, the account block is fully visible, and Sign Out is within the viewport; then clicked Sign Out and confirmed the sheet closes and the nav returns to its signed-out state. Screenshots reviewed at both sizes.

No new i18n keys: the change reuses `navigation.profile` and `navigation.sign_out`, which exist in all four locales.

## Open questions / risks

- A code review confirmed the two non-obvious behaviors: base-ui's `mergeProps` merges same-named handlers rather than overwriting, so `SheetClose` wrapping `button onClick={handleSignOut}` runs both sign-out and close; and `cn()`/twMerge makes `gap-0` cleanly override `SheetContent`'s base `gap-4`.
- Kept the hand-rolled `border-t` instead of the `Separator` primitive: `Separator` hardcodes full-opacity `bg-border`, whereas `border-border/60` matches the nav bar shell.
- One declined review nit: the 40px avatar sits in the same `px-3`/`gap-4` slot as the 24px row icons, so the display name starts 16px right of the labels beneath it. Standard account-menu pattern; the fixes (shrink the avatar, or pad every row icon into a 40px column) cost more than they buy.
