### PR TITLE
fix(auth): route Google sign-in off auth state, not the popup promise

### DIFF
--- a/context/helpers.js
+++ b/context/helpers.js
@@ -4,7 +4,7 @@ import {
   browserPopupRedirectResolver,
   signInWithPopup,
   GoogleAuthProvider,
-  getAdditionalUserInfo,
+  onAuthStateChanged,
 } from '@firebase/auth'
 import moment from 'moment'
 
@@ -40,6 +40,35 @@ export async function createUniqueSlug(
   }
 }
 
+// signInWithPopup races two things: the auth event coming back from the
+// popup, and a poller that rejects with auth/popup-closed-by-user once it
+// sees the popup window closed. Mobile browsers lose that race routinely
+// — the OAuth page opens as a sibling tab, the OS freezes this one while
+// it is backgrounded, and the poller only runs again after the popup is
+// already gone (firebase-js-sdk#7807). The event still lands and still
+// signs the user in, so the rejection says nothing about whether sign-in
+// succeeded; only the auth state does.
+const AUTH_SETTLE_MS = 3000
+
+function awaitSignedInUser(auth, before) {
+  if (auth.currentUser && auth.currentUser !== before)
+    return Promise.resolve(auth.currentUser)
+  return new Promise((resolve) => {
+    let timer
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      if (!user || user === before) return
+      clearTimeout(timer)
+      unsubscribe()
+      resolve(user)
+    })
+    timer = setTimeout(() => {
+      unsubscribe()
+      resolve(null)
+    }, AUTH_SETTLE_MS)
+  })
+}
+
+// Resolves false when sign-in genuinely failed, so the caller can say so.
 export async function providerSignIn(
   auth,
   firestore,
@@ -47,6 +76,12 @@ export async function providerSignIn(
   setProfile
 ) {
   const provider = new GoogleAuthProvider()
+  // A session can already be live here (back button, shared device), and
+  // it must never be mistaken for the result of this sign-in. Every
+  // successful sign-in installs a freshly built User, so identity
+  // comparison separates the two even when the same account re-auths.
+  const before = auth.currentUser
+  let user
   try {
     // Resolver passed per call, not baked into the Auth instance: see
     // lib/firebase.js. This is the only code path that needs the
@@ -57,37 +92,54 @@ export async function providerSignIn(
       provider,
       browserPopupRedirectResolver
     )
-    const addInfo = await getAdditionalUserInfo(res)
-    if (addInfo.isNewUser) {
-      // Complete profile
-      router.push(
-        `/signup/finish${
-          res.user.displayName
-            ? `?first_name=${
-                res.user.displayName.split(' ')[0]
-              }&last_name=${
-                res.user.displayName.split(' ')[1]
-              }`
-            : ''
-        }`
-      )
-    } else {
-      const prof = await getDoc(
-        doc(firestore, 'profiles', res.user.uid)
-      )
-      setProfile(prof.data())
-      const dest = resolveRefPath(router.query.ref)
-      router.push(
-        dest
-          ? dest
-          : prof.data()?.slug
-          ? `/profile/${prof.data().slug}`
-          : '/'
-      )
+    user = res.user
+  } catch (e) {
+    // A second tap supersedes this call; whichever one wins routes.
+    if (e.code === 'auth/cancelled-popup-request')
+      return true
+    user = await awaitSignedInUser(auth, before)
+    if (!user) {
+      console.error(e)
+      return false
     }
+  }
+
+  // Whether the profile doc exists, not getAdditionalUserInfo's
+  // isNewUser: the recovery path above has no UserCredential to read, and
+  // anyone who abandoned /signup/finish still needs sending back there
+  // rather than bouncing to a profile that was never created.
+  let prof
+  try {
+    prof = await getDoc(
+      doc(firestore, 'profiles', user.uid)
+    )
   } catch (e) {
     console.error(e)
+    return false
   }
+  if (!prof.exists()) {
+    const [first_name = '', last_name = ''] = (
+      user.displayName || ''
+    ).split(' ')
+    router.push({
+      pathname: '/signup/finish',
+      query: Object.fromEntries(
+        Object.entries({ first_name, last_name }).filter(
+          ([, v]) => v
+        )
+      ),
+    })
+    return true
+  }
+
+  setProfile(prof.data())
+  const dest = resolveRefPath(router.query.ref)
+  router.push(
+    dest ||
+      (prof.data().slug
+        ? `/profile/${prof.data().slug}`
+        : '/')
+  )
   return true
 }
 

--- a/context/helpers.test.js
+++ b/context/helpers.test.js
@@ -8,6 +8,10 @@ import {
 } from 'vitest'
 import { doc, getDoc } from '@firebase/firestore'
 import {
+  onAuthStateChanged,
+  signInWithPopup,
+} from '@firebase/auth'
+import {
   ALLOWED_LINK_HOSTS,
   ALLOWED_UPLOAD_MIME_TYPES,
   LEGACY_UNSUPPORTED_MIME_TYPES,
@@ -24,6 +28,7 @@ import {
   isAllowedLink,
   isLegacyUnsupportedFile,
   isSafeFileUrl,
+  providerSignIn,
   resolveRefPath,
   validatePassword,
 } from './helpers'
@@ -34,6 +39,13 @@ vi.mock('@firebase/firestore', () => ({
     slug,
   })),
   getDoc: vi.fn(),
+}))
+
+vi.mock('@firebase/auth', () => ({
+  browserPopupRedirectResolver: {},
+  GoogleAuthProvider: vi.fn(),
+  onAuthStateChanged: vi.fn(),
+  signInWithPopup: vi.fn(),
 }))
 
 // Identity translator: lets assertions check against the raw key.
@@ -440,6 +452,243 @@ describe('createUniqueSlug', () => {
     await expect(
       createUniqueSlug({}, 'user2000', 'profile-slugs', 1)
     ).resolves.toBe('user2000-2')
+  })
+})
+
+describe('providerSignIn', () => {
+  const googleUser = {
+    uid: 'uid-1',
+    displayName: 'Ada Lovelace',
+  }
+  const existingProfile = { slug: 'ada-lovelace' }
+
+  function router(query = {}) {
+    return { query, push: vi.fn() }
+  }
+
+  beforeEach(() => {
+    doc.mockClear()
+    getDoc.mockReset()
+    signInWithPopup.mockReset()
+    onAuthStateChanged.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('sends an existing profile to its own page', async () => {
+    signInWithPopup.mockResolvedValue({ user: googleUser })
+    getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => existingProfile,
+    })
+    const r = router()
+    const setProfile = vi.fn()
+
+    await expect(
+      providerSignIn({}, {}, r, setProfile)
+    ).resolves.toBe(true)
+
+    expect(setProfile).toHaveBeenCalledWith(existingProfile)
+    expect(r.push).toHaveBeenCalledWith(
+      '/profile/ada-lovelace'
+    )
+  })
+
+  it('prefers a ?ref= destination over the profile page', async () => {
+    signInWithPopup.mockResolvedValue({ user: googleUser })
+    getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => existingProfile,
+    })
+    const r = router({ ref: 'project|abc123' })
+
+    await providerSignIn({}, {}, r, vi.fn())
+
+    expect(r.push).toHaveBeenCalledWith('/project/abc123')
+  })
+
+  it('sends a user with no profile doc to /signup/finish', async () => {
+    signInWithPopup.mockResolvedValue({ user: googleUser })
+    getDoc.mockResolvedValue({ exists: () => false })
+    const r = router()
+
+    await providerSignIn({}, {}, r, vi.fn())
+
+    expect(r.push).toHaveBeenCalledWith({
+      pathname: '/signup/finish',
+      query: { first_name: 'Ada', last_name: 'Lovelace' },
+    })
+  })
+
+  it('omits name query params when Google gives no display name', async () => {
+    signInWithPopup.mockResolvedValue({
+      user: { uid: 'uid-2', displayName: null },
+    })
+    getDoc.mockResolvedValue({ exists: () => false })
+    const r = router()
+
+    await providerSignIn({}, {}, r, vi.fn())
+
+    expect(r.push).toHaveBeenCalledWith({
+      pathname: '/signup/finish',
+      query: {},
+    })
+  })
+
+  // The mobile bug: the popup poller rejects with
+  // auth/popup-closed-by-user because this tab was frozen while the OAuth
+  // tab was in front, but the auth event still lands and signs the user
+  // in. Routing has to follow the auth state, not the rejection.
+  it('still routes when the popup rejects after sign-in succeeded', async () => {
+    signInWithPopup.mockRejectedValue(
+      Object.assign(new Error('popup closed'), {
+        code: 'auth/popup-closed-by-user',
+      })
+    )
+    const unsubscribe = vi.fn()
+    onAuthStateChanged.mockImplementation((_auth, cb) => {
+      cb(null)
+      setTimeout(() => cb(googleUser), 0)
+      return unsubscribe
+    })
+    getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => existingProfile,
+    })
+    const r = router()
+
+    await expect(
+      providerSignIn({ currentUser: null }, {}, r, vi.fn())
+    ).resolves.toBe(true)
+
+    expect(r.push).toHaveBeenCalledWith(
+      '/profile/ada-lovelace'
+    )
+    expect(unsubscribe).toHaveBeenCalled()
+  })
+
+  it('reports failure when the popup fails and no session appears', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    signInWithPopup.mockRejectedValue(
+      Object.assign(new Error('popup blocked'), {
+        code: 'auth/popup-blocked',
+      })
+    )
+    const unsubscribe = vi.fn()
+    onAuthStateChanged.mockImplementation((_auth, cb) => {
+      cb(null)
+      return unsubscribe
+    })
+    const r = router()
+
+    const pending = providerSignIn(
+      { currentUser: null },
+      {},
+      r,
+      vi.fn()
+    )
+    await vi.advanceTimersByTimeAsync(3000)
+
+    await expect(pending).resolves.toBe(false)
+    expect(r.push).not.toHaveBeenCalled()
+    expect(getDoc).not.toHaveBeenCalled()
+    expect(unsubscribe).toHaveBeenCalled()
+  })
+
+  // A live session on the sign-in page (back button, shared device) is
+  // not evidence that this sign-in worked.
+  it('does not mistake a pre-existing session for a successful sign-in', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const stale = {
+      uid: 'someone-else',
+      displayName: 'Stale',
+    }
+    signInWithPopup.mockRejectedValue(
+      Object.assign(new Error('popup closed'), {
+        code: 'auth/popup-closed-by-user',
+      })
+    )
+    onAuthStateChanged.mockImplementation((_auth, cb) => {
+      cb(stale)
+      return vi.fn()
+    })
+    const r = router()
+    const setProfile = vi.fn()
+
+    const pending = providerSignIn(
+      { currentUser: stale },
+      {},
+      r,
+      setProfile
+    )
+    await vi.advanceTimersByTimeAsync(3000)
+
+    await expect(pending).resolves.toBe(false)
+    expect(r.push).not.toHaveBeenCalled()
+    expect(setProfile).not.toHaveBeenCalled()
+    expect(getDoc).not.toHaveBeenCalled()
+  })
+
+  it('accepts a fresh session that replaces a pre-existing one', async () => {
+    const stale = { uid: 'someone-else' }
+    signInWithPopup.mockRejectedValue(
+      Object.assign(new Error('popup closed'), {
+        code: 'auth/popup-closed-by-user',
+      })
+    )
+    onAuthStateChanged.mockImplementation((_auth, cb) => {
+      setTimeout(() => cb(googleUser), 0)
+      return vi.fn()
+    })
+    getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => existingProfile,
+    })
+    const r = router()
+
+    await expect(
+      providerSignIn({ currentUser: stale }, {}, r, vi.fn())
+    ).resolves.toBe(true)
+
+    expect(r.push).toHaveBeenCalledWith(
+      '/profile/ada-lovelace'
+    )
+  })
+
+  // A second tap cancels the first request; the winner does the routing,
+  // so the superseded call must not paint an error over it.
+  it('stays quiet when a second tap supersedes the request', async () => {
+    signInWithPopup.mockRejectedValue(
+      Object.assign(new Error('cancelled'), {
+        code: 'auth/cancelled-popup-request',
+      })
+    )
+    const r = router()
+
+    await expect(
+      providerSignIn({ currentUser: null }, {}, r, vi.fn())
+    ).resolves.toBe(true)
+
+    expect(r.push).not.toHaveBeenCalled()
+    expect(onAuthStateChanged).not.toHaveBeenCalled()
+  })
+
+  it('reports failure when the profile lookup throws', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    signInWithPopup.mockResolvedValue({ user: googleUser })
+    getDoc.mockRejectedValue(new Error('unavailable'))
+    const r = router()
+
+    await expect(
+      providerSignIn({}, {}, r, vi.fn())
+    ).resolves.toBe(false)
+
+    expect(r.push).not.toHaveBeenCalled()
   })
 })
 

--- a/e2e/google-signin.spec.js
+++ b/e2e/google-signin.spec.js
@@ -1,0 +1,165 @@
+// Google sign-in is the only flow that leaves the app for another origin
+// and comes back, and the only one that routes to the signed-in user's
+// own profile. Both branches of providerSignIn are covered: no profile
+// doc yet -> /signup/finish, profile doc present -> /profile/<slug>.
+//
+// Driven at a phone viewport because that is where the reported bug
+// showed up. Headless Chromium never freezes the opener tab, so it cannot
+// reproduce the popup poller losing its race with the auth event
+// (firebase-js-sdk#7807) — that recovery path is unit-tested in
+// context/helpers.test.js. What this locks in is the routing either side
+// of it, through the real SDK and the real router.
+//
+// Waits are generous because this is the only spec that reaches
+// /signup/finish, /profile/<slug> and /project/<id>, and `next dev`
+// compiles each of them on first visit while other workers are running.
+const { test, expect } = require('@playwright/test')
+const {
+  adminApp,
+  uniqueSuffix,
+} = require('./support/admin')
+const { waitForHydration } = require('./support/ui')
+
+test.use({ viewport: { width: 390, height: 844 } })
+
+async function signInWithGoogle(page, { email, display }) {
+  const [popup] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.getByRole('button', { name: /Google/i }).click(),
+  ])
+  await popup.waitForLoadState('domcontentloaded')
+
+  const known = popup
+    .locator('li.js-reuse-account')
+    .filter({ hasText: email })
+  if (await known.count()) {
+    await known.first().click()
+  } else {
+    await popup.locator('#add-account-button').click()
+    await popup.locator('#email-input').fill(email)
+    await popup.locator('#display-name-input').fill(display)
+    await popup.locator('#sign-in').click()
+  }
+  await popup.waitForEvent('close', { timeout: 60_000 })
+}
+
+// Auth persistence is IndexedDB-backed (lib/firebase.js), so dropping the
+// database and reloading is a sign-out the emulator's IdP session
+// survives — which is what lets the second sign-in reuse the account.
+async function signOut(page) {
+  await page.evaluate(
+    () =>
+      new Promise((resolve) => {
+        const req = indexedDB.deleteDatabase(
+          'firebaseLocalStorageDb'
+        )
+        req.onsuccess = resolve
+        req.onerror = resolve
+        req.onblocked = resolve
+      })
+  )
+  await page.evaluate(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+}
+
+test('Google sign-in routes to /signup/finish, then to the profile page', async ({
+  page,
+}) => {
+  const suffix = uniqueSuffix()
+  const email = `e2e-google-${suffix}@example.com`
+  const display = 'Ada Lovelace'
+
+  await page.goto('/signin/student')
+  await waitForHydration(page, '#email')
+  await signInWithGoogle(page, { email, display })
+
+  // No profiles/<uid> doc yet, so the user has to finish signing up —
+  // with the name Google handed back already filled in.
+  await page.waitForURL(/\/signup\/finish/, {
+    timeout: 60_000,
+  })
+  await expect(page.locator('#first_name')).toHaveValue(
+    'Ada'
+  )
+  await expect(page.locator('#last_name')).toHaveValue(
+    'Lovelace'
+  )
+
+  const user = await adminApp().auth().getUserByEmail(email)
+  const slug = `ada-lovelace-${suffix}`
+  await adminApp()
+    .firestore()
+    .collection('profiles')
+    .doc(user.uid)
+    .set({
+      uid: user.uid,
+      display,
+      authorized: true,
+      slug,
+      about: '',
+      fields: [],
+      programs: [],
+      links: [],
+      joined: new Date().toISOString(),
+      institution: '',
+      position: '',
+      subs_p: [],
+      subs_e: [],
+      mentor: false,
+    })
+  await adminApp()
+    .firestore()
+    .collection('profile-slugs')
+    .doc(slug)
+    .set({ slug })
+
+  await signOut(page)
+  await page.goto('/signin/student')
+  await waitForHydration(page, '#email')
+  await signInWithGoogle(page, { email, display })
+
+  await page.waitForURL(`/profile/${slug}`, {
+    timeout: 60_000,
+  })
+})
+
+test('Google sign-in honours ?ref= over the profile page', async ({
+  page,
+}) => {
+  test.skip(
+    !process.env.E2E_FILTER_MODERN_PROJECT_ID,
+    'global setup did not seed a fixture project'
+  )
+  const projectId = process.env.E2E_FILTER_MODERN_PROJECT_ID
+  const suffix = uniqueSuffix()
+  const email = `e2e-google-ref-${suffix}@example.com`
+  const display = 'Grace Hopper'
+
+  await page.goto('/signup/student')
+  await waitForHydration(page, '#first_name')
+  await signInWithGoogle(page, { email, display })
+  await page.waitForURL(/\/signup\/finish/, {
+    timeout: 60_000,
+  })
+
+  const user = await adminApp().auth().getUserByEmail(email)
+  const slug = `grace-hopper-${suffix}`
+  await adminApp()
+    .firestore()
+    .collection('profiles')
+    .doc(user.uid)
+    .set({ uid: user.uid, display, authorized: true, slug })
+
+  await signOut(page)
+  await page.goto(
+    `/signin/student?ref=project|${projectId}`
+  )
+  await waitForHydration(page, '#email')
+  await signInWithGoogle(page, { email, display })
+
+  await page.waitForURL(`/project/${projectId}`, {
+    timeout: 60_000,
+  })
+})

--- a/next.config.js
+++ b/next.config.js
@@ -160,7 +160,9 @@ module.exports = {
               // (__/auth/iframe) that signInWithPopup/signInWithRedirect
               // uses to relay auth events — the project id varies per
               // deployment (dev/staging/prod) and isn't available to this
-              // config at container runtime, hence the wildcard.
+              // config at container runtime, hence the wildcard. The Auth
+              // emulator serves the same iframe from 127.0.0.1:9099, so
+              // dev/e2e Google sign-in needs it too.
               // firebasestorage.googleapis.com/storage.googleapis.com —
               // components/FileGallery.js embeds an uploaded PDF's own
               // download URL in an <iframe> for in-page viewing.
@@ -170,6 +172,10 @@ module.exports = {
               // without them here every embed is a blank frame.
               `frame-src https://www.google.com https://*.firebaseapp.com ${
                 authDomain ? `https://${authDomain} ` : ''
+              }${
+                isDevelopment
+                  ? 'http://127.0.0.1:9099 '
+                  : ''
               }https://firebasestorage.googleapis.com https://storage.googleapis.com https://*.firebasestorage.app https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com https://w.soundcloud.com https://open.spotify.com; ` +
               `connect-src ${connectSrc}; ` +
               "frame-ancestors 'self'; " +

--- a/pages/signin/student.js
+++ b/pages/signin/student.js
@@ -1,4 +1,4 @@
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 
 import Link from 'next/link'
 import Image from 'next/image'
@@ -44,6 +44,7 @@ export default function StudentSignIn() {
   const { t } = useTranslation('common')
   const router = useRouter()
   const { setProfile } = useContext(AppContext)
+  const [googlePending, setGooglePending] = useState(false)
 
   const f_signin_errors = {
     'auth/invalid-email': t('auth.auth_invalid_email'),
@@ -210,22 +211,41 @@ export default function StudentSignIn() {
           type="button"
           size="lg"
           className="h-11 w-full gap-2 text-base"
-          onClick={() =>
-            providerSignIn(
+          disabled={googlePending}
+          onClick={async () => {
+            setGooglePending(true)
+            const signedIn = await providerSignIn(
               auth,
               firestore,
               router,
               setProfile
             )
-          }
+            // Left pending on success: the route transition is already
+            // under way, and re-enabling only flashes the button.
+            if (!signedIn) {
+              setGooglePending(false)
+              form.setError(
+                'email',
+                {
+                  type: 'server',
+                  message: t('auth.sign_in_failed'),
+                },
+                { shouldFocus: true }
+              )
+            }
+          }}
         >
-          <Image
-            src="/assets/logos/Google.png"
-            alt=""
-            width={20}
-            height={20}
-            className="size-5"
-          />
+          {googlePending ? (
+            <LoadingSpinner />
+          ) : (
+            <Image
+              src="/assets/logos/Google.png"
+              alt=""
+              width={20}
+              height={20}
+              className="size-5"
+            />
+          )}
           {t('auth.google_sign_in')}
         </Button>
       </AuthCard>

--- a/pages/signup/student.js
+++ b/pages/signup/student.js
@@ -521,22 +521,43 @@ export default function StudentSignUp() {
           type="button"
           size="lg"
           className="h-11 w-full text-base"
-          onClick={() =>
-            providerSignIn(
+          disabled={loading}
+          onClick={async () => {
+            setLoading(true)
+            const signedIn = await providerSignIn(
               auth,
               firestore,
               router,
               setProfile
             )
-          }
+            // Reset only on failure, as emailSignUp does: on success the
+            // route transition is already under way. Focused, not just
+            // rendered, because the email field is six fields up from
+            // this button and would otherwise be off-screen on a phone.
+            if (!signedIn) {
+              setLoading(false)
+              form.setError(
+                'email',
+                {
+                  type: 'server',
+                  message: t('auth.sign_in_failed'),
+                },
+                { shouldFocus: true }
+              )
+            }
+          }}
         >
-          <Image
-            src="/assets/logos/Google.png"
-            alt=""
-            width={20}
-            height={20}
-            className="size-5"
-          />
+          {loading ? (
+            <LoadingSpinner />
+          ) : (
+            <Image
+              src="/assets/logos/Google.png"
+              alt=""
+              width={20}
+              height={20}
+              className="size-5"
+            />
+          )}
           {t('auth.google_sign_in')}
         </Button>
       </AuthCard>

--- a/tests/pages/signin/student.test.js
+++ b/tests/pages/signin/student.test.js
@@ -37,10 +37,11 @@ vi.mock('@firebase/firestore', () => ({
 }))
 
 vi.mock('@firebase/auth', () => ({
+  browserPopupRedirectResolver: {},
   signInWithEmailAndPassword: vi.fn(),
   signInWithPopup: vi.fn(),
   GoogleAuthProvider: vi.fn(),
-  getAdditionalUserInfo: vi.fn(),
+  onAuthStateChanged: vi.fn(),
 }))
 
 afterEach(cleanup)

--- a/tests/pages/signup/student.test.js
+++ b/tests/pages/signup/student.test.js
@@ -64,12 +64,13 @@ const mockRecaptchaRender = vi
   .mockResolvedValue(undefined)
 
 vi.mock('@firebase/auth', () => ({
+  browserPopupRedirectResolver: {},
   createUserWithEmailAndPassword: vi.fn(),
   updateProfile: vi.fn(),
   signInWithEmailAndPassword: vi.fn(),
   signInWithPopup: vi.fn(),
   GoogleAuthProvider: vi.fn(),
-  getAdditionalUserInfo: vi.fn(),
+  onAuthStateChanged: vi.fn(),
   // `mockImplementation` can't take an arrow function here — the
   // component calls `new RecaptchaVerifier(...)`, and arrow functions
   // aren't constructable.


### PR DESCRIPTION
## What changed

**`context/helpers.js` — `providerSignIn`**
- Routing follows the **auth state**, not the popup promise. If `signInWithPopup` rejects, `awaitSignedInUser` waits up to 3s for `onAuthStateChanged` before declaring failure.
- A session that was already live before the popup is excluded by identity comparison (`auth.currentUser !== before`). Every successful sign-in installs a freshly built `User`, so this holds even when the same account re-auths.
- `auth/cancelled-popup-request` short-circuits: a second tap supersedes this call, and the winner routes.
- New-vs-existing is derived from whether `profiles/<uid>` exists, replacing `getAdditionalUserInfo(...).isNewUser`. Forced by the recovery path having no `UserCredential`, and it also fixes users who abandoned `/signup/finish` — they used to be dumped on `/` forever.
- The profile read is wrapped, so the function resolves `false` instead of rejecting into an unguarded `async onClick`.

**`pages/signin/student.js`, `pages/signup/student.js`** — Google button awaits the result, disables with a `LoadingSpinner` while in flight, and on failure renders `t('auth.sign_in_failed')` with `{ shouldFocus: true }`. No new i18n keys; the string already exists in en/es/fr/hi.

**`next.config.js`** — `frame-src` allows `http://127.0.0.1:9099` in development only, mirroring the existing `connect-src` precedent. Production CSP unchanged.

**Tests** — `context/helpers.test.js` (10 cases for `providerSignIn`), new `e2e/google-signin.spec.js` (2 cases at a 390x844 viewport), plus mock-factory alignment in the two page tests.

## Why

`signInWithPopup` races the incoming auth event against a poller that rejects once it sees the popup window closed:

```js
// @firebase/auth 1.13.4, platform_browser/strategies/popup.ts:301
if (this.authWindow?.window?.closed) {
  this.pollId = window.setTimeout(() => this.reject(
    _createError(this.auth, AuthErrorCode.POPUP_CLOSED_BY_USER)), 8000)
```

On mobile the OAuth page opens as a **sibling tab**, not a popup (`platform_browser/util/popup.ts:75` — `openAsNewWindowIOS`, `_isChromeIOS` -> `_blank`), so the OS freezes the app tab behind it. On resume the poller can win and reject, but the auth event still lands and still signs the user in. Old code did `catch (e) { console.error(e) }`: signed in, never routed, no feedback. (firebase-js-sdk#7807)

**`signInWithRedirect` was deliberately not used.** `authDomain` is `<project-id>.firebaseapp.com`, a different *site* from the app domain, so Safari 16.1+ storage partitioning would break redirect outright — trading a race for a hard failure on iOS. Popup is correct here; it just had to stop discarding successful sign-ins.

## Validation

- `pnpm test:unit` — **452 passed / 32 files**.
- **Regression proven twice.** With `HEAD:context/helpers.js` restored, all 6 original `providerSignIn` tests fail. With only the two stale-session identity checks reverted, `does not mistake a pre-existing session for a successful sign-in` fails. Both pass on the fix.
- `pnpm exec playwright test e2e/google-signin.spec.js e2e/signup-redirect.spec.js` — 4 passed, driving the real SDK popup against the Firebase emulator and the real Next router.
- **Browser smoke at 390x844**: in flight -> button `disabled`, logo swapped for spinner. After cancelling the popup -> re-enabled, logo restored, "Sign in failed. Please try again or create an account." rendered, `document.activeElement.id === 'email'`.
- `pnpm lint` (pre-existing warnings only), `pnpm format` clean, `pnpm build` green.

## Open questions / risks

- **A deliberate cancel now takes ~11s to show its message**: 8s of the SDK's own `_Timeout.AUTH_EVENT` grace (unavoidable with popup) plus `AUTH_SETTLE_MS = 3000`. Shortening the latter risks missing the very case this fixes — on tab resume the queued auth event still needs a credential round trip to identitytoolkit, which is seconds on mobile. Strictly better than the old behaviour, which showed nothing ever; the spinner keeps it from reading as a dead button.
- **The frozen-tab race is not reproducible in headless Chromium** (it never freezes the opener), so the e2e locks in the routing either side of it and the unit tests cover the recovery path directly.
- **Not included**: a signed-in redirect guard on the auth pages. It would make the stale-session scenario unreachable, but that is a broader behaviour change than this bug warrants, and the identity check fixes the defect at its source.
- **Unrelated, pre-existing**: `e2e/project-visuals.spec.js:105` fails on clean `main` (confirmed by stashing). Fixture duplication — `getByText('Broken Photo Project')` resolves to 2 elements when global-setup seeds into a reused emulator. Worth a separate fix.
